### PR TITLE
added bindings.xml for quick window toggle

### DIFF
--- a/LFGBulletinBoard/bindings.xml
+++ b/LFGBulletinBoard/bindings.xml
@@ -1,0 +1,5 @@
+<Bindings>
+  <Binding name="Open/Close LFGBulletinBoard" description="Opens/Closes LFGBulletinBoard Window" header="LFGBulletinBoardBinding">
+    GroupBulletinBoard_Addon:ToggleWindow()
+  </Binding>
+</Bindings>


### PR DESCRIPTION
Allows quick window toggle from keybind.
Keybind can be set in Settings -> Key Bindings -> Other

![image](https://user-images.githubusercontent.com/3444087/121762517-6503fd00-cb04-11eb-9ea7-c37900c6abbf.png)
