### PR TITLE
Fix for heroic not properly identifed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+LFGBulletinBoard/readme_de.txt

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -264,16 +264,16 @@ function GBB.CreateTagListLOC(loc)
 		end
 	end
 
-	local arr = {}
 	for _, tag in pairs(GBB.heroicTagsLoc[loc]) do
-		arr[tag] = 1
+		GBB.HeroicKeywords[tag] = 1
 	end
-	GBB.HeroicKeywords = arr
 end
 
 function GBB.CreateTagList ()
 	GBB.tagList={}
 	GBB.suffixTags={}
+	GBB.HeroicKeywords={}
+
 	if GBB.DB.TagsEnglish then
 		GBB.CreateTagListLOC("enGB")
 	end

--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -1,7 +1,7 @@
 ## Interface: 20501
 ## Title: LFG Bulletin Board
 ## Notes: Sort LFG/LFM Messages
-## Version: 2.52
+## Version: 2.53
 ## Author: Vyscî-Whitemane original by GPI / Erytheia-Razorfen
 ## DefaultState: enabled
 ## SavedVariables: GroupBulletinBoardDB

--- a/LFGBulletinBoard/changelog.txt
+++ b/LFGBulletinBoard/changelog.txt
@@ -2,6 +2,9 @@
 
 Group Bulletin Board 	
 
+2.53
+ - Fix for heroic not filtering properly when custom in search patterns is checked
+ 
 2.52
  - Added HC to heroics
  - Refactored to allow the option to configure heroic tags


### PR DESCRIPTION
If you had "custom" selected in search patterns it wouldn't properly identify heroics. Fixed the issue