### PR TITLE
Use official channel name in French

### DIFF
--- a/LFGBulletinBoard/Localization.lua
+++ b/LFGBulletinBoard/Localization.lua
@@ -237,7 +237,7 @@ GBB.locales = {
 		["world_channel"] = "Mundo",
 	},
 	frFR = {
-		["lfg_channel"]="RechercheGroupe",
+		["lfg_channel"]="RechercheDeGroupe",
 		["world_channel"] = "Monde"
 	},
 	ruRU = {	


### PR DESCRIPTION
The official channel name in french is "RechercheDeGroupe" and not "RechercheGroupe"; using the wrong channel name has a side effect as joining it first and forces it to be channel number 1 (/1) - User can always join "RechercheGroupe" and check this channel in settings pannel to use it, but default channel must be the official one.