### PR TITLE
Allowing heroic dungeons when filtering by level

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -124,12 +124,16 @@ function GBB.LevelRange(dungeon,short)
 end
 
 function GBB.FilterDungeon(dungeon, isHeroic, isRaid)
-	if dungeon==nil then return false end
+	if dungeon == nil then return false end
 	if isHeroic == nil then isHeroic = false end
 	if isRaid == nil then isRaid = false end
+
+	-- If the user is within the level range, or if they're max level and it's heroic.
+	local inLevelRange = (GBB.dungeonLevel[dungeon][1] <= GBB.UserLevel and GBB.UserLevel <= GBB.dungeonLevel[dungeon][2]) or (isHeroic and GBB.UserLevel == 70)
 	
-	return GBB.DBChar["FilterDungeon"..dungeon] and (isRaid or ((GBB.DBChar["HeroicOnly"] == false or isHeroic) and (GBB.DBChar["NormalOnly"] == false or isHeroic == false))) and
-		(GBB.DBChar.FilterLevel==false or (GBB.dungeonLevel[dungeon][1] <= GBB.UserLevel and GBB.UserLevel <= GBB.dungeonLevel[dungeon][2]))
+	return GBB.DBChar["FilterDungeon"..dungeon] and 
+		(isRaid or ((GBB.DBChar["HeroicOnly"] == false or isHeroic) and (GBB.DBChar["NormalOnly"] == false or isHeroic == false))) and
+		(GBB.DBChar.FilterLevel == false or inLevelRange)
 end
 
 function GBB.formatTime(sec) 


### PR DESCRIPTION
This allows the user to enable 'filter by level', and show heroics with low normal levels (such as Ramparts).