### PR TITLE
Fix timer race condition

### DIFF
--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -188,9 +188,17 @@ local function CreateItem(yy,i,doCompact,req,forceHight)
 
 		local ti
 		if GBB.DB.ShowTotalTime then
-			ti=GBB.formatTime(time()-req.start)
+			if (time() - req.start < 0) then -- Quick fix for negative timers that happen as a result of new time calculation.
+				ti=GBB.formatTime(0) 
+			else
+				ti=GBB.formatTime(time()-req.start)
+			end
 		else
-			ti=GBB.formatTime(time()-req.last)
+			if (time() - req.last < 0) then
+				ti=GBB.formatTime(0)
+			else
+				ti=GBB.formatTime(time()-req.last)
+			end
 		end
 
 		local typePrefix
@@ -352,9 +360,6 @@ function GBB.UpdateList()
 			table.sort(GBB.RequestList, requestSort_nTOP_nTOTAL)
 		end
 	end
-
-
-
 
 	for i, f in pairs(GBB.FramesEntries) do
 		f:Hide()
@@ -619,16 +624,17 @@ function GBB.GetDungeons(msg,name)
 		end
 	end
 
-
 	return dungeons, isGood, isBad, wordcount, isHeroic
-
 end
 
 function GBB.ParseMessage(msg,name,guid,channel)
 	if GBB.Initalized==false or name==nil or name=="" or msg==nil or msg=="" or string.len(msg)<4 then
 		return
 	end
-	local requestTime=time()
+
+	local appendTime = tonumber("0." .. math.random(100,999)) -- Append a random "millisecond" value. 
+	local requestTime=tonumber(time() + appendTime)
+
 	local doUpdate=false
 
 	local locClass,engClass,locRace,engRace,Gender,gName,gRealm = GetPlayerInfoByGUID(guid)


### PR DESCRIPTION
Fixing a race condition with timers that made requests rapidly swap spaces with another request if they were made at the same time.

See: https://www.curseforge.com/wow/addons/lfg-group-finder-bulletin-board?comment=474
