### PR TITLE
Allow better isolation of summoning services popular in SoD

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -113,6 +113,7 @@ function GBB.GetDungeonNames()
 		["BAD"] =	"DEBUG BAD WORDS - REJECTED",
 		["BREW"] =  "Brewfest - Coren Direbrew",
 		["HOLLOW"] =  "Hallow's End - Headless Horseman",
+    ["TRAVEL"] = "Travel services - Summons/Portals",
 		}
 
 	local dungeonNamesLocales={
@@ -642,7 +643,7 @@ GBB.VanillaDungeonLevels ={
 	["LBRS"] = 	{55,60}, ["DME"] = 	{58,60}, ["DMN"] = 	{58,60}, ["DMW"] = 	{58,60}, ["STR"] = 	{58,60}, ["SCH"] = 	{58,60},
 	["UBRS"] = 	{58,60}, ["MC"] = 	{60,60}, ["ZG"] = 	{60,60}, ["AQ20"]= 	{60,60}, ["BWL"] = {60,60},
 	["AQ40"] = 	{60,60}, ["NAX"] = 	{60,60},
-	["MISC"]= {0,100},
+	["MISC"]=   {0,100}, ["TRAVEL"]={0,100},
 	["DEBUG"] = {0,100}, ["BAD"] =	{0,100}, ["TRADE"]=	{0,100}, ["SM2"] =  {28,42}, ["DM2"] =	{58,60}, ["DEADMINES"]={18,23},
 }
 
@@ -653,7 +654,7 @@ GBB.PostTbcDungeonLevels = {
 	["LBRS"] = 	{54,60}, ["DME"] = 	{54,61}, ["DMN"] = 	{54,61}, ["DMW"] = 	{54,61}, ["STR"] = 	{56,61}, ["SCH"] = 	{56,61},
 	["UBRS"] = 	{53,61}, ["MC"] = 	{60,60}, ["ZG"] = 	{60,60}, ["AQ20"]= 	{60,60}, ["BWL"] = {60,60},
 	["AQ40"] = 	{60,60}, ["NAX"] = 	{60,60},
-	["MISC"]= {0,100},
+	["MISC"] =  {0,100}, ["TRAVEL"]={0,100},
 	["DEBUG"] = {0,100}, ["BAD"] =	{0,100}, ["TRADE"]=	{0,100}, ["SM2"] =  {28,42}, ["DM2"] =	{58,60}, ["DEADMINES"]={16,24},
 }
 
@@ -703,7 +704,7 @@ GBB.PvpNames = {
 	"WSG", "AB", "AV", "EOTS", "WG", "SOTA", "ARENA",
 }
 
-GBB.Misc = {"MISC", "TRADE",}
+GBB.Misc = {"MISC", "TRADE", "TRAVEL"}
 
 GBB.DebugNames = {
 	"DEBUG", "BAD", "NIL",

--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -85,7 +85,7 @@ local function InviteRequestWithRole(gbbName,gbbDungeon,gbbHeroic,gbbRaid)
 	end
 
 	-- Not sure if necessary, but Heroic Miscellaneous sounds like a dangerous place.
-	if gbbDungeon == "MISC" or gbbDungeon == "TRADE" then
+	if gbbDungeon == "MISC" or gbbDungeon == "TRADE" or gbbDungeon == "TRAVEL" then
 		gbbDungeonPrefix = ""
 	end
 

--- a/LFGBulletinBoard/Localization.lua
+++ b/LFGBulletinBoard/Localization.lua
@@ -81,6 +81,7 @@ GBB.locales = {
 		["CboxEnableGuild"]="Add guild in player tooltip",
 		["CboxCombineSubDungeons"]="Combine sub-dungeons like Dire Maul (only new request)",
 		["CboxAdditionalInfo"]="Add more info to chat on /who and when somebody comes online",
+		["CboxIsolateTravelServices"]="Prevent travel services from appearing in other categories",
 
 		["CboxNotfiyInnone"]="Enable on overworld",
 		["CboxNotfiyInpvp"]="Enable in battleground",

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -168,6 +168,7 @@ function GBB.OptionsInit ()
 	GBB.Options.AddDrop(GBB.DB,"FontSize", "GameFontNormal", {"GameFontNormalSmall", "GameFontNormal", "GameFontNormalLarge"}) 
 
 	CheckBox("CombineSubDungeons",false)
+	CheckBox("IsolateTravelServices",false)
 	GBB.Options.AddSpace()
 	CheckBox("NotifySound",false)
 	CheckBox("NotifyChat",false)

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -308,7 +308,7 @@ local function InviteRequestWithRole(gbbName,gbbDungeon,gbbHeroic,gbbRaid)
 	end
 
 	-- Not sure if necessary, but Heroic Miscellaneous sounds like a dangerous place.
-	if gbbDungeon == "MISC" or gbbDungeon == "TRADE" then
+	if gbbDungeon == "MISC" or gbbDungeon == "TRADE" or gbbDungeon == "TRAVEL" then
 		gbbDungeonPrefix = ""
 	end
 
@@ -630,6 +630,17 @@ function GBB.GetDungeons(msg,name)
 						dungeons[ip]=true
 						dungeons[subDungeon]=nil
 					end
+				end
+			end
+		end
+	end
+
+	-- isolate travel services so they don't show up in groups
+	if GBB.DB.IsolateTravelServices then
+		if dungeons["TRAVEL"] then
+			for ip,p in pairs(dungeons) do
+				if ip~="TRAVEL" then
+					dungeons[ip]=false
 				end
 			end
 		end

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -151,6 +151,7 @@ GBB.dungeonTagsLoc={
 		["BREW"] =  "brewfest brew coren dire direbrew beerfest",
 		["HOLLOW"] = "headless horseman hollow",
 		["TRADE"] = "buy buying sell selling wts wtb hitem henchant htrade enchanter", --hlink
+		["TRAVEL"] = "sum summ summon summons summoning port portal travel"
 	}),
 	deDE =langSplit({
 		["RFC"] = 	"rfa ragefireabgrund flammenschlund flamenschlund rf rfg" ,


### PR DESCRIPTION
With Season of Discovery both trade and LFG have been hammered with people advertising fast traveling services.  This change lets you separate those into their own category.  

It also brings a new checkbox that will prevent those services from showing up in the trade bulletin list or in a dungeon

For example, take the following message

> [2. Trade] WTS Summons for Scarlet Monastery - (GY LIB ARMORY CATH) 

### Before:

**Good:** If you are looking for a SM summon: you would see this in trade bulletin or perhaps a SM bulletin
**Bad:** If you are trying to find an enchanter in the Trade bulletins this message would show up the trade bulletins (and there are _a lot_ of these summon services spamming)
**Bad:** If you are trying to find a SM LIB group this would show up in the SM LIB bulletins

### After:

**Good:** If you are looking for a SM summon: you would see this in trade bulletin or perhaps a SM bulletin _or_ a new Travel Service bulletin list
**Good:** If you are trying to find an enchanter in the Trade bulletins and have selected "Isolate travel services" this message would no longer show up the trade bulletins
**Good:** If you are trying to find a SM LIB group and have selected "Isolate travel services" this would no longer show up in the SM LIB bulletins
