### PR TITLE
feat: add support for `CUSTOM_CLASS_COLORS` table

### DIFF
--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -362,8 +362,8 @@ local function CreateItem(yy,i,doCompact,req,forceHight)
 
 	if req and req.name ~= nil then
 		local prefix
-		if GBB.DB.ColorByClass and req.class and RAID_CLASS_COLORS[req.class].colorStr then
-			prefix="|c"..RAID_CLASS_COLORS[req.class].colorStr
+		if GBB.DB.ColorByClass and req.class and GBB.Tool.ClassColor[req.class].colorStr then
+			prefix="|c"..GBB.Tool.ClassColor[req.class].colorStr
 		else
 			prefix="|r"
 		end

--- a/LFGBulletinBoard/LibGPIToolBox.lua
+++ b/LFGBulletinBoard/LibGPIToolBox.lua
@@ -51,6 +51,16 @@ Tool.RoleIcon = {
 Tool.Classes=CLASS_SORT_ORDER
 Tool.ClassName=LOCALIZED_CLASS_NAMES_MALE
 Tool.ClassColor=RAID_CLASS_COLORS
+-- support for CUSTOM_CLASS_COLORS
+if CUSTOM_CLASS_COLORS then
+	for k, v in pairs(CUSTOM_CLASS_COLORS) do
+		---@cast v ColorMixin
+		if not v.colorStr then
+			v.colorStr = v:GenerateHexColor();
+		end
+		Tool.ClassColor[k] = v;
+	end
+end
 
 Tool.NameToClass={}
 for eng,name in pairs(LOCALIZED_CLASS_NAMES_MALE) do

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -1,4 +1,4 @@
-local 	TOCNAME,GBB=...
+local TOCNAME, GBB = ...
 
 --ScrollList / Request
 -------------------------------------------------------------------------------------
@@ -162,8 +162,8 @@ local function CreateItem(yy,i,doCompact,req,forceHight)
 
 	if req then
 		local prefix
-		if GBB.DB.ColorByClass and req.class and RAID_CLASS_COLORS[req.class].colorStr then
-			prefix="|c"..RAID_CLASS_COLORS[req.class].colorStr
+		if GBB.DB.ColorByClass and req.class and GBB.Tool.ClassColor[req.class].colorStr then
+			prefix="|c"..GBB.Tool.ClassColor[req.class].colorStr
 		else
 			prefix="|r"
 		end
@@ -780,7 +780,7 @@ function GBB.ParseMessage(msg,name,guid,channel)
 			local FriendIcon=(C_FriendList.IsFriend(guid) and string.format(GBB.TxtEscapePicture,GBB.FriendIcon) or "") ..
 						 ((IsInGuild() and IsGuildMember(guid)) and string.format(GBB.TxtEscapePicture,GBB.GuildIcon) or "") ..
 						 (GBB.GroupTrans[name]~=nil and string.format(GBB.TxtEscapePicture,GBB.PastPlayerIcon) or "" )
-			local linkname=	"|Hplayer:"..name.."|h[|c"..RAID_CLASS_COLORS[engClass].colorStr ..name.."|r]|h"
+			local linkname=	"|Hplayer:"..name.."|h[|c"..GBB.Tool.ClassColor[engClass].colorStr ..name.."|r]|h"
 			if GBB.DB.OneLineNotification then
 				DEFAULT_CHAT_FRAME:AddMessage(GBB.MSGPREFIX..linkname..FriendIcon..": "..msg,GBB.DB.NotifyColor.r,GBB.DB.NotifyColor.g,GBB.DB.NotifyColor.b)
 			else


### PR DESCRIPTION
Related Issue:
 - #209  

Removed any direct indexing of `RAID_CLASS_COLOR` in favor of `Addon.Tool.ClassColor`.

`Addon.Tool.ClassColor` now references the `CUSTOM_CLASS_COLOR` table when found.