### PR TITLE
[WIP] Classic Redux (Era + Cata)

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -1,5 +1,8 @@
 local TOCNAME,GBB=...
 
+local isClassicEra = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local isSoD = isClassicEra and C_Seasons.GetActiveSeason() == Enum.SeasonID.SeasonOfDiscovery
+
 local function getSeasonalDungeons()
     local events = {}
 
@@ -13,11 +16,7 @@ local function getSeasonalDungeons()
 end
 
 local function getPvpByVersion()
-	local version, build, date, tocversion = GetBuildInfo()
-	if string.sub(version, 1, 2) ~= "1." then
-		return GBB.PvpNames
-	end
-	return GBB.PvpSodNames
+	return isSoD and GBB.PvpSodNames or GBB.PvpNames
 end
 
 function GBB.GetDungeonNames()
@@ -776,6 +775,47 @@ local function GetSize(list)
 end
 
 function GBB.GetDungeonSort()
+	if isClassicEra then
+		-- No seasonal event dungeons in Era
+		-- for eventName, eventData in pairs(GBB.Seasonal) do
+		-- 	if GBB.Tool.InDateRange(eventData.startDate, eventData.endDate) then
+		-- 		table.insert(GBB.WotlkDungeonNames, 1, eventName)
+		-- 	else
+		-- 		table.insert(GBB.DebugNames, 1, eventName)
+		-- 	end
+		-- end
+	
+		local orderedNameLists = { GBB.VanillDungeonNames, GBB.PvpNames, GBB.Misc, GBB.DebugNames}
+	
+		local vanillaDungeonSize = GBB.GetNumClassicDungeons()
+		local debugSize = GetSize(GBB.DebugNames)
+		
+		local orderedNames, numEntries = ConcatenateLists(orderedNameLists)
+		local dungeonSort = {}
+	
+		GBB.MAXDUNGEON = vanillaDungeonSize
+		GBB.ENDINGDUNGEONSTART = GBB.MAXDUNGEON + 1
+		GBB.ENDINGDUNGEONEND = numEntries - debugSize - 1
+		
+		-- needed to not error out code atm
+		GBB.TBCDUNGEONSTART = 1
+		GBB.TBCMAXDUNGEON = 0
+		GBB.WOTLKDUNGEONSTART = 1
+		GBB.WOTLKMAXDUNGEON = 0
+	
+		for dungeonKey, sortIdx in pairs(orderedNames) do
+			dungeonSort[sortIdx] = dungeonKey
+			dungeonSort[dungeonKey] = sortIdx
+		end
+	
+		-- Need to do this because I don't know I am too lazy to debug the use of SM2, DM2, and DEADMINES
+		dungeonSort["SM2"] = 10.5
+		dungeonSort["DM2"] = 19.5
+		dungeonSort["DEADMINES"] = 99
+	
+		return dungeonSort
+
+	end
 	for eventName, eventData in pairs(GBB.Seasonal) do
         if GBB.Tool.InDateRange(eventData.startDate, eventData.endDate) then
 			table.insert(GBB.WotlkDungeonNames, 1, eventName)

--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -880,6 +880,9 @@ local hiddenKeys = {"SM2", "DM2", "DEADMINES"}
 ---Returns a table with the min and max level for each dungeon/raid/battleground
 ---@return table<string, table<number, number>>
 local function DetermineVanillaDungeonRange()
+	if not isClassicEra then 
+		return GBB.PostTbcDungeonLevels
+	end
 	---@type table<DungeonID, DungeonInfo>
 	local classicDungeonInfo = GBB.GetClassicDungeonInfo()
 	local keyToDungeonID = GBB.GetClassicDungeonKeys()

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -426,6 +426,8 @@ function GBB.Popup_Minimap(frame,notminimap)
 		GBB.PopupDynamic:AddItem(GBB.L["CboxLockMinimapButtonDistance"],false,GBB.DB.MinimapButton,"lockDistance")
 	end
 	GBB.PopupDynamic:AddItem("",true)
+	GBB.PopupDynamic:AddItem(GBB.L["BtnResetWindow"],false,GBB.ResetWindow)
+	GBB.PopupDynamic:AddItem("",true)
 	GBB.PopupDynamic:AddItem(GBB.L["BtnCancel"],false)
 		
 	GBB.PopupDynamic:Show(frame,0,0)

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -820,7 +820,7 @@ function GBB.OnUpdate(elapsed)
 		end;
 
 		if GBB.ElapsedSinceLfgUpdate > 18 and GBB.Tool.GetSelectedTab(GroupBulletinBoardFrame)==2 and GroupBulletinBoardFrame:IsVisible() then
-			LFGBrowseFrameRefreshButton:Click()
+			-- LFGListFrame.SearchPanel.RefreshButton:Click() -- hwevent protected
 			GBB.UpdateLfgTool()
 			GBB.ElapsedSinceLfgUpdate = 0
 		else

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -123,15 +123,21 @@ function GBB.GetMessageWordList(msg)
 	return results	
 end
 
+---@param dungeon string dunegon key
+---@param short boolean if true, returns a short version of the level range
+---@return string # formatted level range string ie "10-20" or "Level 10-20"
 function GBB.LevelRange(dungeon,short)
-	if short then 
-		if GBB.dungeonLevel[dungeon][1]>0 then
-			return string.format(GBB.L["msgLevelRangeShort"],GBB.dungeonLevel[dungeon][1],GBB.dungeonLevel[dungeon][2])
-		end
-	elseif GBB.dungeonLevel[dungeon][1]>0 then
-		return string.format(GBB.L["msgLevelRange"],GBB.dungeonLevel[dungeon][1],GBB.dungeonLevel[dungeon][2])
+	local hasLevel = GBB.dungeonLevel[dungeon][1] > 0
+	if hasLevel then
+		local templateText = short and GBB.L["msgLevelRangeShort"] or GBB.L["msgLevelRange"]
+		return string.format(
+			templateText,
+			GBB.dungeonLevel[dungeon][1],
+			GBB.dungeonLevel[dungeon][2]
+		);
+	else
+		return ""
 	end
-	return ""
 end
 
 ---@return boolean `true` if the dungeon should be tracked on bulletin board, `false` otherwise.

--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -1,4 +1,4 @@
-## Interface: 11502
+## Interface: 11502, 40400
 ## Title: LFG Bulletin Board
 ## Notes: Sort LFG/LFM Messages
 ## Version: 3.24
@@ -6,6 +6,7 @@
 ## DefaultState: enabled
 ## SavedVariables: GroupBulletinBoardDB
 ## SavedVariablesPerCharacter: GroupBulletinBoardDBChar
+data/dungeons/cata.lua
 data/dungeons/classic.lua
 LibGPIOptions.lua
 LibGPIMinimapButton.lua

--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -6,6 +6,7 @@
 ## DefaultState: enabled
 ## SavedVariables: GroupBulletinBoardDB
 ## SavedVariablesPerCharacter: GroupBulletinBoardDBChar
+utils/debug.lua
 data/dungeons/cata.lua
 data/dungeons/classic.lua
 LibGPIOptions.lua

--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -6,6 +6,7 @@
 ## DefaultState: enabled
 ## SavedVariables: GroupBulletinBoardDB
 ## SavedVariablesPerCharacter: GroupBulletinBoardDBChar
+data/dungeons/classic.lua
 LibGPIOptions.lua
 LibGPIMinimapButton.lua
 LibGPIToolBox.lua

--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -208,34 +208,34 @@ function GBB.GetLfgList()
 end
 
 function GBB.UpdateLfgTool()
-    if LFGBrowseFrame and LFGBrowseFrame.CategoryDropDown.selectedValue == 120 then return end
-    if  LFGBrowseFrame and LFGBrowseFrame.CategoryDropDown.selectedValue == nil then  
-        LFGBrowseFrame.CategoryDropDown.selectedValue = 2
+    if LFGListFrame and LFGListFrame.CategorySelection.selectedCategory == 120 then return end
+    if  LFGListFrame and LFGListFrame.CategorySelection.selectedCategory == nil then  
+        LFGListFrame.CategorySelection.selectedCategory = 2
     end
 
     LastUpdateTime = time()
     GBB.LfgRequestList = {}
     
     local category = 2
-    if LFGBrowseFrame and LFGBrowseFrame.CategoryDropDown.selectedValue ~= nil then 
-        category = LFGBrowseFrame.CategoryDropDown.selectedValue
+    if LFGListFrame and LFGListFrame.CategorySelection.selectedCategory ~= nil then 
+        category = LFGListFrame.CategorySelection.selectedCategory
     end
 
 	local activities = C_LFGList.GetAvailableActivities(category)
 	--C_LFGList.Search(category, activities)
-    if LFGBrowseFrame and LFGBrowseFrame.searching then return end
+    if LFGListFrame and LFGListFrame.searching then return end
 
 	GBB.GetLfgList()
     GBB.LfgUpdateList()
 end
 
 function GBB.UpdateLfgToolNoSearch()
-    if LFGBrowseFrame.CategoryDropDown.selectedValue == 120 then return end
-    if  LFGBrowseFrame.CategoryDropDown.selectedValue == nil then  
-        LFGBrowseFrame.CategoryDropDown.selectedValue = 2
+    if LFGListFrame.CategorySelection.selectedCategory == 120 then return end
+    if  LFGListFrame.CategorySelection.selectedCategory == nil then  
+        LFGListFrame.CategorySelection.selectedCategory = 2
     end
 
-if LFGBrowseFrame.searching then return end
+if LFGListFrame and LFGListFrame.searching then return end
 
     GBB.LfgRequestList = {}
     GBB.GetLfgList()

--- a/LFGBulletinBoard/Localization.lua
+++ b/LFGBulletinBoard/Localization.lua
@@ -115,6 +115,7 @@ GBB.locales = {
 		["BtnPlayerNoteColor"]="Color of the player note",
 		["BtnColorGuild"]="Colour of the guild text",
 		["BtnPostMsg"] = "Post",
+		["BtnResetWindow"]="Reset Window Position",
 
 		["SlashReset"]="Reset main window position",
 		["SlashConfig"]="Open configuration",
@@ -352,6 +353,8 @@ GBB.locales = {
 	["BtnPlayerNoteColor"]="Couleur de la note du joueur",
 	["BtnColorGuild"]="Couleur du texte de la guilde",
 	["BtnPostMsg"] = "Poster",
+	["BtnResetWindow"]="Reset Window Position",
+
 	["SlashReset"]="Réinitialiser la position de la fenêtre principale",
 	["SlashConfig"]="Ouvrir la configuration",
 	["SlashDefault"]="Ouvrir la fenêtre principale",
@@ -382,6 +385,8 @@ GBB.locales = {
 		["BtnNotifyColor"]="Цвет уведомительного сообщения",
 		["BtnSelectAll"]="Выбрать все",
 		["BtnPostMsg"]="Объявить",
+		["BtnResetWindow"]="Reset Window Position",
+
 		["BtnStopAnnounceMsg"]="Остановить автоматическое объявление",
 		["BtnTimeColor"]="Цвет времени",
 		["BtnPlayerNoteColor"]="Цвет заметки об игроке",
@@ -585,6 +590,7 @@ GBB.locales = {
 		["BtnPlayerNoteColor"]="玩家註記顏色",
 		["BtnColorGuild"]="公會文字顏色",
 		["BtnPostMsg"] = "發佈",
+		["BtnResetWindow"]="Reset Window Position",
 
 		["SlashReset"]="重設主視窗位置",
 		["SlashConfig"]="開啟設定",
@@ -714,6 +720,7 @@ GBB.locales = {
 		["BtnPlayerNoteColor"]="玩家姓名颜色",
 		["BtnColorGuild"]="公会文字颜色",
 		["BtnPostMsg"] = "发布",
+		["BtnResetWindow"]="Reset Window Position",
 
 		["SlashReset"]="重设主窗口位置",
 		["SlashConfig"]="开启设置",

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -57,8 +57,6 @@ GBB.heroicTagsLoc=langSplit({
 	zhCN = "h H 英雄",
 })
 
-
-
 GBB.dungeonTagsLoc={
 	enGB = langSplit({
 		["RFC"] = 	"rfc ragefire chasm" ,
@@ -589,36 +587,6 @@ GBB.dungeonSecondTags = {
 	["DM2"] = {"DMW","DME","DMN","-DM"},
 }
 
-if isClassicEra then 
-	-- purge any un-used tags
-	local validDungeons = GBB.GetClassicDungeonKeys()
-	local exceptions = {
-		-- misc categories that should be tracked
-		["TRADE"] = true,
-		["TRAVEL"] = true,
-		["BLOOD"] = true,
-		["INCUR"] = true,
-		-- addon has 2 different keys for nax, should be fixed at some point.
-		["NAXX"] = true, 
-
-	}
-	for locale, tagList in pairs(GBB.dungeonTagsLoc) do
-		local alerted = {}
-		for dungeonKey, _ in pairs(tagList) do
-			if not (validDungeons[dungeonKey] 
-				or exceptions[dungeonKey]
-				or GBB.dungeonSecondTags[dungeonKey])
-			then
-				GBB.dungeonTagsLoc[locale][dungeonKey] = nil
-				if not alerted[dungeonKey] then
-					alerted[dungeonKey] = true
-					-- print("Removed unused dungeon tag for "..dungeonKey)
-				end
-			end
-		end
-	end
-end
-
 GBB.dungeonTagsLoc.enGB["DEADMINES"]={"dm"}
 -- Remove any unused dungeon tags based on game version
 if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
@@ -661,5 +629,11 @@ if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
 				GBB.dungeonTagsLoc[locale][dungeonKey] = nil
 			end
 		end
+	end
+else
+	-- remove bloodmoon and incursion tags from all locales
+	for locale, dungeonTags in pairs(GBB.dungeonTagsLoc) do
+		dungeonTags["BLOOD"] = nil
+		dungeonTags["INCUR"] = nil
 	end
 end

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -1,6 +1,7 @@
 local TOCNAME,GBB=...
 
 -- IMPORTANT, everything must be in low-case and with now space!
+local isClassicEra = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
 
 local function langSplit(source)
 	local ret={}
@@ -573,6 +574,19 @@ GBB.dungeonTagsLoc={
 		["TRADE"] = "买 卖 收 代工 出售 附魔",
 	}),
 }
+
+if isClassicEra then 
+	-- purge any un-used tags
+	local validDungeons = GBB.GetClassicDungeonCodes()
+	for locale, tagList in pairs(GBB.dungeonTagsLoc) do
+		for dungeonKey, _ in pairs(tagList) do
+			if not validDungeons[dungeonKey] then
+				GBB.dungeonTagsLoc[locale][dungeonKey] = nil
+				print("GBB: Removed unused dungeon tag for "..dungeonKey)
+			end
+		end
+	end
+end
 
 GBB.dungeonTagsLoc.enGB["DEADMINES"]={"dm"}
 

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -88,6 +88,7 @@ GBB.dungeonTagsLoc={
 		["SCH"] = 	"scholomance scholo sholo sholomance",
 		["LBRS"] = 	"lower lbrs lrbs",
 		["UBRS"] =	"upper ubrs urbs rend",
+
 		["RAMPS"] = "ramparts rampart ramp ramps",
 		["BF"] = "furnace furn bf",
 		["SP"] = 	"slavepens pens sp",
@@ -139,6 +140,7 @@ GBB.dungeonTagsLoc={
 		["HYJAL"] = "hyjal hs hyj",
 		["BT"] = 	"bt",
 		["SWP"] = 	"swp sunwell plateau plataeu sunwel",
+
 		["ONY"] = 	"onyxia ony",
 		["MC"]  = 	"molten core mc",
 		["ZG"]  = 	"zg gurub zul'gurub zulgurub zul´gurub zul`gurub zulg",
@@ -147,6 +149,7 @@ GBB.dungeonTagsLoc={
 		["AQ40"] = 	"aq40" ,
 		["NAX"] = 	"placeholdernax",
 		["NAXX"] = 	"naxxramas nax naxx nax10 naxx10 nax25 naxx25",
+		
 		["WSG"] = 	"wsg warsong ws",
 		["AB"]  = 	"basin ab",
 		["AV"]  = 	"av valley",
@@ -609,7 +612,7 @@ if isClassicEra then
 				GBB.dungeonTagsLoc[locale][dungeonKey] = nil
 				if not alerted[dungeonKey] then
 					alerted[dungeonKey] = true
-					print("Removed unused dungeon tag for "..dungeonKey)
+					-- print("Removed unused dungeon tag for "..dungeonKey)
 				end
 			end
 		end

--- a/LFGBulletinBoard/data/dungeons/cata.lua
+++ b/LFGBulletinBoard/data/dungeons/cata.lua
@@ -1,0 +1,320 @@
+local _, addon = ...
+
+if WOW_PROJECT_ID ~= WOW_PROJECT_CATACLYSM_CLASSIC then return end
+---@alias ExpansionID 0|1|2|3|4|5
+assert(GetLFGDungeonInfo, _ .. " requires the API `GetLFGDungeonInfo` for parsing dungeon info")
+assert(GetRealZoneText, _ .. " requires the API `GetRealZoneText` for parsing dungeon info")
+assert(C_LFGList.GetActivityInfoTable, _ .. " requires the API `C_LFGList.GetActivityInfoTable` for parsing dungeon info")
+
+
+-- intialize here for now, this should be moved to a file thats always grunteed to load first.
+---@class AddonEnum
+addon.Enum = addon.Enum or {} 
+
+---@type DungeonTypeID
+local DungeonType = {
+    Dungeon = 1,
+    Raid = 2,
+    None = 4,
+    Battleground = 5,
+    Random = 6,
+}
+
+---@enum InstanceTypeID
+local InstanceType = {
+    NoInstance = 0,
+    Party = 1,
+    Raid = 2,
+    Battleground = 3,
+    Arena = 4,
+}
+
+-- The keys to this table need to be manually matched to the appropriate dungeonID
+-- These same keys are used for identifying the preset tags/keywords for each dungeon. If a tags Key is missing from this table, the tags will not be registered.
+-- modifications here should be reflected in the `Tags.lua` file and vice versa.
+local LFGDungeonIDs = {
+	RBG = 358,	-- 10v10 Rated Battleground
+	AQ20 = 160,	-- Ahn'Qiraj Ruins
+	AQ40 = 161,	-- Ahn'Qiraj Temple
+	ANK = 218,	-- Ahn'kahet: The Old Kingdom
+	CRYPTS = 149,	-- Auchenai Crypts
+	AZN = 204,	-- Azjol-Nerub
+	NULL = 328,	-- Baradin Hold
+	BT = 196,	-- Black Temple
+	BFD = 10,   -- Blackfathom Deeps
+	NULL = 303,	-- Blackrock Caverns
+	NULL = 30,  -- Blackrock Depths - Detention Block
+	NULL = 276,	-- Blackrock Depths - Upper City
+	NULL = 313,	-- Blackwing Descent
+	BWL = 50,   -- Blackwing Lair
+	BF = 137,	-- Blood Furnace
+	BREW = 287,	-- Coren Direbrew
+	NULL = 297,	-- Crown Princess Theradras
+	DM = 6,     -- Deadmines
+	NULL = 36, 	-- Dire Maul - Capital Gardens
+	NULL = 38,  -- Dire Maul - Gordok Commons
+	NULL = 34,  -- Dire Maul - Warpwood Quarter
+	NULL = 447,	-- Dragon Soul
+	DTK = 214,	-- Drak'Tharon Keep
+	NULL = 435,	-- End Time
+	NULL = 417,	-- Fall of Deathwing
+	NULL = 361,	-- Firelands
+	GNO = 14,   -- Gnomeregan
+	NULL = 296,	-- Grand Ambassador Flamelash
+	NULL = 304,	-- Grim Batol
+	GL = 177,	-- Gruul's Lair
+	GD = 216,	-- Gundrak
+	HOL = 207,	-- Halls of Lightning
+	NULL = 305,	-- Halls of Origination
+	HOR = 255,	-- Halls of Reflection
+	HOS = 208,	-- Halls of Stone
+	RAMPS = 136,-- Hellfire Ramparts
+	NULL = 439,	-- Hour of Twilight
+	HYJAL = 195,-- Hyjal Past
+	ICC = 279,	-- Icecrown Citadel
+	NULL = 298,	-- Kai'ju Gahz'rilla
+	KARA = 175,	-- Karazhan
+	NULL = 312,	-- Lost City of the Tol'vir
+	LBRS = 32,  -- Lower Blackrock Spire
+	MGT = 198,	-- Magisters' Terrace
+	NULL = 176,	-- Magtheridon's Lair
+	MT = 148,	-- Mana-Tombs
+
+    -- all these can get put into "MARA"
+	NULL = 273,	-- Maraudon - Earth Song Falls
+	NULL = 26,  -- Maraudon - Foulspore Cavern
+	NULL = 272,	-- Maraudon - The Wicked Grotto
+
+	MC = 48,    -- Molten Core
+	NAXX = 159,	-- Naxxramas
+	ONY = 46,   -- Onyxia's Lair
+	-- BM = 171,	-- Opening of the Dark Portal (See Black Morass in ActivityIDs)
+	POS = 253,	-- Pit of Saron
+	NULL = 299,	-- Prince Sarsarun
+    RFC = 4,    -- Ragefire Chasm
+	RFD = 20,   -- Razorfen Downs
+	RFK = 16,   -- Razorfen Kraul
+	RS = 293,	-- Ruby Sanctum
+	SMA = 163,	-- Scarlet Monastery - Armory
+	SMC = 164,	-- Scarlet Monastery - Cathedral
+	SMG = 18,   -- Scarlet Monastery - Graveyard
+	SML = 165,	-- Scarlet Monastery - Library
+	SCH = 2,    -- Scholomance
+	SSC = 194,	-- Serpentshrine Cavern
+	SETH = 150,	-- Sethekk Halls
+	SL = 151,	-- Shadow Labyrinth
+	SFK = 8,    -- Shadowfang Keep
+	SH = 138,	-- Shattered Halls
+	SP = 140,	-- Slave Pens
+	STK = 12,   -- Stormwind Stockade
+	NULL = 40,  -- Stratholme - Main Gate
+	NULL = 274,	-- Stratholme - Service Entrance
+	ST = 28,    -- Sunken Temple
+	EYE = 193,	-- Tempest Keep (The Eye)
+	ARC = 174,	-- The Arcatraz
+	NULL = 315,	-- The Bastion of Twilight
+	BOT = 173,	-- The Botanica
+	NULL = 288,	-- The Crown Chemical Co.
+	COS = 209,	-- The Culling of Stratholme
+	OHB = 170,	-- The Escape From Durnholde (Old Hillsbrad Foothills)
+	EOE = 223,	-- The Eye of Eternity
+	FOS = 251,	-- The Forge of Souls
+	NULL = 286,	-- The Frost Lord Ahune
+	NULL = 285,	-- The Headless Horseman
+	MECH = 172,	-- The Mechanar
+	NEX = 225,	-- The Nexus
+	OS = 224,	-- The Obsidian Sanctum
+	OCC = 206,	-- The Oculus
+	NULL = 416,	-- The Siege of Wyrmrest Temple
+	SV = 147,	-- The Steamvault
+	NULL = 307,	-- The Stonecore
+	SWP = 199,	-- The Sunwell
+	NULL = 311,	-- The Vortex Pinnacle
+	NULL = 317,	-- Throne of the Four Winds
+	NULL = 302,	-- Throne of the Tides
+	CHAMP = 245,-- Trial of the Champion
+	TOGC = {
+        246,	-- Trial of the Crusader
+	    247,	-- Trial of the Grand Crusader
+    },
+	ULD = 22,   -- Uldaman
+	ULDAR = 243,-- Ulduar
+	UB = 146,	-- Underbog
+	UBRS = 330,	-- Upper Blackrock Spire
+	UK = 202,	-- Utgarde Keep
+	UP = 203,	-- Utgarde Pinnacle
+	VOA = 239,	-- Vault of Archavon
+	VH = 220,	-- Violet Hold
+	WC = 1,     -- Wailing Caverns
+	NULL = 437,	-- Well of Eternity
+	ZA = 340,	-- Zul'Aman
+	ZF = 24,    -- Zul'Farrak
+	ZG = 334,	-- Zul'Gurub 
+}
+local dungeonIDToKey = {}
+for key, dungeonID in pairs(LFGDungeonIDs) do
+    if type(dungeonID) == "table" then
+        for _, id in ipairs(dungeonID) do
+            dungeonIDToKey[id] = key
+        end
+    else
+        dungeonIDToKey[dungeonID] = key
+    end
+end
+-- Following have no DungeonID in cata client so use a related ActivityID
+local ActivityIDs = {
+    ARENA = {
+        936,    -- 2v2 Arena
+        937,    -- 3v3 Arena
+        938     -- 5v5 Arena
+    },
+	AV = 932,	-- Alterac Valley
+	AB = 926,	-- Arathi Basin
+	BRD = 811,	-- Blackrock Depths 
+	EOTS = 934,	-- Eye of the Storm
+	NULL = 1144,	-- Isle of Conquest
+	SOTA = 1142,	-- Strand of the Ancients
+	STR = 816,	-- Stratholme
+	BM = 831,	-- The Black Morass
+	WSG = 919,	-- Warsong Gulch
+    -- MARA = 809,	-- Maraudon (now split into 3 wings)
+	-- STK = 802,	-- Stormwind Stockades (Use "Stormwind Stockade")
+	-- UB = 821,	-- Coilfang - Underbog (Just use Underbog)
+	-- DME = 813,	-- Dire Maul - East (Depracted in Cata)
+	-- DMN = 815,	-- Dire Maul - North (Depracted in Cata)
+	-- DMW = 814,	-- Dire Maul - West (Depracted in Cata)
+}
+local activityIDToKey = {}
+for key, activityID in pairs(ActivityIDs) do
+    if type(activityID) == "table" then
+        for _, id in ipairs(activityID) do
+            activityIDToKey[id] = key
+        end
+    else
+        activityIDToKey[activityID] = key
+    end
+end
+
+local CLIENT_LOCALE = GetLocale()
+
+local debug = true
+local print = function(...) if debug then addon.print(...) end end
+
+-- see https://wago.tools/db2/LFGDungeons?build=3.4.3.54261
+
+
+---@type {[DungeonID]: DungeonInfo}
+local dungeonInfoCache = {}
+local numDungeons = 0
+do
+    -- only cache dungeons, raids, and battlegrounds
+    local function cacheActivityInfo(activityID)
+        local cacheInfo = {}
+        local activityInfo = C_LFGList.GetActivityInfoTable(activityID)
+        cacheInfo = {
+            name = activityInfo.shortName or activityInfo.fullName,
+            minLevel = activityInfo.minLevel,
+            maxLevel = activityInfo.maxLevel,
+            tagKey = activityIDToKey[activityID],
+            -- mapID = activityInfo.mapID,
+        }
+        if not cacheInfo.name then
+            print(_ .. ": Failed to get dungeon info for ID: " .. activityID)
+            return;
+        end
+        assert(not dungeonInfoCache[activityID], "Duplicate ID found for activity ID: " .. activityID, "Use a different dungeonID for this dungeon or different activityID", activityInfo)
+        dungeonInfoCache[activityID] = cacheInfo
+        numDungeons = numDungeons + 1
+    end
+    local function cacheLFGDungeonInfo(dungeonID)
+        local info = {}
+        local dungeonInfo = {GetLFGDungeonInfo(dungeonID)}
+        local name, typeID, subtypeID, minLevel, maxLevel = 
+            dungeonInfo[1], dungeonInfo[2], dungeonInfo[3], dungeonInfo[4], dungeonInfo[5];
+        local expansionID = dungeonInfo[9]
+        -- local mapID = dungeonInfo[22]
+        assert(name, "Failed to get dungeon info for ID: " .. dungeonID..". Valid dungeonIDs require for addon to function.")
+        assert(typeID and minLevel and maxLevel and expansionID, "Failed to get level range or type for dungeonID: " .. dungeonID, name, typeID, minLevel, maxLevel, expansionID)
+        info = {
+            name = name,
+            minLevel = minLevel,
+            maxLevel = maxLevel,
+            typeID = typeID,
+            subtypeID = subtypeID,
+            tagKey = dungeonIDToKey[dungeonID],
+            expansionID = 0,
+        } --[[@as DungeonInfo]]
+        assert(not dungeonInfoCache[dungeonID], "Duplicate ID found for dungeon ID: " .. dungeonID, "Use a different dungeonID for this dungeon or different dungeonID", dungeonInfo)
+        dungeonInfoCache[dungeonID] = info
+        numDungeons = numDungeons + 1
+        -- print(_ .. ": Skipping dunegeon " .. info.name .. " dungeonID: " .. dungeonID .. " typeID: " .. info.typeID)
+    end
+    for dungeonKey in pairs(LFGDungeonIDs) do
+        local dungeonID = LFGDungeonIDs[dungeonKey]
+        if type(dungeonID) == "table" then
+            for _, id in ipairs(dungeonID) do
+                cacheLFGDungeonInfo(id)
+            end
+        else
+            cacheLFGDungeonInfo(dungeonID)
+        end
+    end
+    for activityKey in pairs(ActivityIDs) do
+        local activityID = ActivityIDs[activityKey]
+        if type(activityID) == "table" then
+            for _, id in ipairs(activityID) do
+                cacheActivityInfo(id)
+            end
+        else
+            cacheActivityInfo(activityID)
+        end
+    end
+end
+
+local localizedNames -- cache to save some iteration cycles.
+---@return {[DungeonID]: string} # Table mapping `dungeonID` to it's localized name.
+--- Because of holes in the `dungeonID` range, use `pairs` to iterate table.
+function addon.GetCataLocalizedDungeonNames()
+    if not localizedNames then
+        localizedNames = {}
+        for dungeonID, info in pairs(dungeonInfoCache) do
+            assert(info.name, "Missing name for dungeonID: " .. dungeonID)
+            localizedNames[dungeonID] = info.name
+        end
+    end
+    return localizedNames
+end
+
+---@return {[string]: DungeonID} # Table mapping `dungeonCode` to it's `dungeonID` if it's a valid dungeon
+local allKeys = {}
+function addon.GetCataDungeonKeys()
+    for dungeonID, key in pairs(dungeonIDToKey) do
+        allKeys[key] = dungeonID
+    end
+    for activityID, key in pairs(activityIDToKey) do
+        allKeys[key] = activityID
+    end
+    allKeys.NULL = nil
+    return allKeys
+end
+
+function addon.GetNumCataDungeons()
+    return numDungeons
+end
+
+---Returns **all** dungeon info if `dungeonID` is nil; Otherwise, returns info for the specificed `dungeonID` or `nil` if it doesn't exist.
+---@param dungeonID DungeonID?
+---@return (DungeonInfo|table<DungeonID, DungeonInfo>)? 
+function addon.GetCataDungeonInfo(dungeonID)
+    -- CopyTable isnt neccessary, but its probably best to prevent someone from breaking the addon by messing with out internal table if we return a reference here.
+    if dungeonID then
+        local info = dungeonInfoCache[dungeonID]
+        if info then
+            return CopyTable(dungeonInfoCache[dungeonID])
+        end
+    else
+        return CopyTable(dungeonInfoCache)
+    end
+end
+
+addon.cataDungeonInfo = dungeonInfoCache

--- a/LFGBulletinBoard/data/dungeons/cata.lua
+++ b/LFGBulletinBoard/data/dungeons/cata.lua
@@ -6,27 +6,17 @@ assert(GetLFGDungeonInfo, _ .. " requires the API `GetLFGDungeonInfo` for parsin
 assert(GetRealZoneText, _ .. " requires the API `GetRealZoneText` for parsing dungeon info")
 assert(C_LFGList.GetActivityInfoTable, _ .. " requires the API `C_LFGList.GetActivityInfoTable` for parsing dungeon info")
 
+local print = addon.print
 
 -- intialize here for now, this should be moved to a file thats always grunteed to load first.
 ---@class AddonEnum
-addon.Enum = addon.Enum or {} 
-
----@type DungeonTypeID
-local DungeonType = {
-    Dungeon = 1,
-    Raid = 2,
-    None = 4,
-    Battleground = 5,
-    Random = 6,
-}
-
----@enum InstanceTypeID
-local InstanceType = {
-    NoInstance = 0,
-    Party = 1,
-    Raid = 2,
-    Battleground = 3,
-    Arena = 4,
+addon.Enum = addon.Enum or { } 
+---@enum ExpansionID
+addon.Enum.Expansions = {
+	Classic = 0,
+	BurningCrusade = 1,
+	Wrath = 2,
+	Cataclysm = 3,
 }
 
 -- The keys to this table need to be manually matched to the appropriate dungeonID
@@ -228,10 +218,11 @@ do
     end
     local function cacheLFGDungeonInfo(dungeonID)
         local info = {}
+		-- https://warcraft.wiki.gg/wiki/API_GetLFGDungeonInfo
         local dungeonInfo = {GetLFGDungeonInfo(dungeonID)}
         local name, typeID, subtypeID, minLevel, maxLevel = 
             dungeonInfo[1], dungeonInfo[2], dungeonInfo[3], dungeonInfo[4], dungeonInfo[5];
-        local expansionID = dungeonInfo[9]
+        local expansionID, isHoliday = dungeonInfo[9], dungeonInfo[15]
         -- local mapID = dungeonInfo[22]
         assert(name, "Failed to get dungeon info for ID: " .. dungeonID..". Valid dungeonIDs require for addon to function.")
         assert(typeID and minLevel and maxLevel and expansionID, "Failed to get level range or type for dungeonID: " .. dungeonID, name, typeID, minLevel, maxLevel, expansionID)
@@ -242,7 +233,8 @@ do
             typeID = typeID,
             subtypeID = subtypeID,
             tagKey = dungeonIDToKey[dungeonID],
-            expansionID = 0,
+			isHoliday = isHoliday,
+            expansionID = expansionID,
         } --[[@as DungeonInfo]]
         assert(not dungeonInfoCache[dungeonID], "Duplicate ID found for dungeon ID: " .. dungeonID, "Use a different dungeonID for this dungeon or different dungeonID", dungeonInfo)
         dungeonInfoCache[dungeonID] = info

--- a/LFGBulletinBoard/data/dungeons/classic.lua
+++ b/LFGBulletinBoard/data/dungeons/classic.lua
@@ -242,7 +242,7 @@ local infoOverrides = {
 local dungeonCodeByID = {
     [3] = "RFC",
     [1] = "WC",
-    [5] = "DEADMINES",
+    [5] = "DM", -- Deadmines
     [7] = "SFK",
     [11] = "STK", -- Stocks,
     [9] = "BFD",
@@ -334,8 +334,6 @@ do
     end
 end
 
-
-
 local localizedNames -- cache to save some iteration cycles.
 ---@return {[DungeonID]: string} # Table mapping `dungeonID` to it's localized name.
 --- Because of holes in the `dungeonID` range, use `pairs` to iterate table.
@@ -351,7 +349,7 @@ function addon.GetClassicLocalizedDungeonNames()
 end
 
 local raidCache
----@return {[DungeonID]: DungeonInfo} # Table mapping `dungeonID` to it's info.
+---@return {[DungeonID]: DungeonInfo} # Table mapping `dungeonID` to it's info
 --- Because of holes in the `dungeonID` range, use `pairs` to iterate table.
 function addon.GetClassicRaids()
     if not raidCache then
@@ -366,4 +364,10 @@ function addon.GetClassicRaids()
     return raidCache
 end
 
-addon.localizedDungeonIfno = dungeonInfoCache
+---@return {[string]: DungeonID} # Table mapping `dungeonCode` to it's `dungeonID` if it's a valid dungeon
+local dunegeonIDByCode = tInvert(dungeonCodeByID)
+function addon.GetClassicDungeonCodes()
+    return dunegeonIDByCode
+end
+
+addon.localizedDungeonInfo = dungeonInfoCache

--- a/LFGBulletinBoard/data/dungeons/classic.lua
+++ b/LFGBulletinBoard/data/dungeons/classic.lua
@@ -239,7 +239,7 @@ local infoOverrides = {
 
 -- manually associate keys in Tags.lua
 -- this is definately not sustainable outside of classic
-local dungeonCodeByID = {
+local dungeonKeyByID = {
     [3] = "RFC",
     [1] = "WC",
     [5] = "DM", -- Deadmines
@@ -259,10 +259,10 @@ local dungeonCodeByID = {
     [25] = "MAR",
     [27] = "ST",
     [29] = "BRD",
-    [33] = "DM2",  -- Base "Dire Maul" DNE
-    [34] = "DME",
-    [36] = "DMN",
-    [38] = "DMW",
+    [32] = "DM2",  -- Base "Dire Maul" DNE
+    [33] = "DME",
+    [35] = "DMW",
+    [37] = "DMN",
     [39] = "STR", -- Strat
     [2] = "SCH",  -- Scholo
     [31] = "LBRS",
@@ -299,7 +299,7 @@ do
                 maxLevel = maxLevel,
                 typeID = typeID,
                 subtypeID = subtypeID,
-                tagKey = dungeonCodeByID[dungeonID],
+                tagKey = dungeonKeyByID[dungeonID],
             }
         end
         if not info.name then
@@ -367,12 +367,27 @@ function addon.GetClassicRaids()
 end
 
 ---@return {[string]: DungeonID} # Table mapping `dungeonCode` to it's `dungeonID` if it's a valid dungeon
-local dunegeonIDByCode = tInvert(dungeonCodeByID)
-function addon.GetClassicDungeonCodes()
-    return dunegeonIDByCode
+local dunegeonIDByKey = tInvert(dungeonKeyByID)
+function addon.GetClassicDungeonKeys()
+    return dunegeonIDByKey
 end
 
 function addon.GetNumClassicDungeons()
     return numDungeons
+end
+
+---Returns **all** dungeon info if `dungeonID` is nil; Otherwise, returns info for the specificed `dungeonID` or `nil` if it doesn't exist.
+---@param dungeonID DungeonID?
+---@return (DungeonInfo|table<DungeonID, DungeonInfo>)? 
+function addon.GetClassicDungeonInfo(dungeonID)
+    -- CopyTable isnt neccessary, but its probably best to prevent someone from breaking the addon by messing with out internal table if we return a reference here.
+    if dungeonID then
+        local info = dungeonInfoCache[dungeonID]
+        if info then
+            return CopyTable(dungeonInfoCache[dungeonID])
+        end
+    else
+        return CopyTable(dungeonInfoCache)
+    end
 end
 addon.localizedDungeonInfo = dungeonInfoCache

--- a/LFGBulletinBoard/data/dungeons/classic.lua
+++ b/LFGBulletinBoard/data/dungeons/classic.lua
@@ -1,0 +1,369 @@
+local _, addon = ...
+
+-- exists in classic even though no Dungeon Finder.
+assert(GetLFGDungeonInfo, _ .. " requires the API `GetLFGDungeonInfo` for parsing dungeon info")
+
+---@enum DungeonTypeID
+local DungeonType = {
+    Dungeon = 1,
+    Raid = 2,
+    Battleground = 5,
+}
+
+---@alias DungeonID number
+
+---@class DungeonInfo
+---@field name string # Game client localized name of the dungeon
+---@field minLevel number
+---@field maxLevel number
+---@field typeID DungeonTypeID -- 1 = dungeon, 2 = raid, 5 = bg
+---@field subtypeID number? -- not really neeeded
+
+--see https://wago.tools/db2/LFGDungeons?build=1.15.2.54332
+-- NOTE: classic db only has up to 131 in the db
+-- this excludes individual SM wings, AQ20, AQ40, and Naxx
+-- they are in wotlk client, stopping at 165
+local MAX_DUNGEON_ID = 165;
+
+local CLIENT_LOCALE = GetLocale()
+local isSoD = C_Seasons and (C_Seasons.GetActiveSeason() == Enum.SeasonID.SeasonOfDiscovery)
+
+local debug = false
+local print = function(...) if debug then print(...) end end
+
+-- see https://wago.tools/db2/LFGDungeons?build=3.4.3.54261 (for Naxx and AQ20/40)
+-- Because classic era client db only has up to ID 131, `GetLFGDungeonInfo` will return nil for these. (and 18)
+-- (as of 1.15.2.54332, ymmv)
+local manualEntries = {
+    [159] = {
+        name = {
+            enUS = "Naxxramas",
+            deDE = "Naxxramas",
+            esES = "Naxxramas",
+            esMX = "Naxxramas",
+            frFR = "Naxxramas",
+            itIT = "Naxxramas",
+            koKR = "낙스라마스",
+            ptBR = "Naxxramas",
+            ruRU = "Наксрамас",
+            zhCN = "纳克萨玛斯",
+            zhTW = "納克薩瑪斯",
+        },
+        minLevel = 60,
+        maxLevel = 60,
+        typeID = 2,
+        subtypeID = 0,
+    },
+    [160] = {
+        name = {
+            enUS = "Ahn'Qiraj Ruins",
+            deDE = "Ruinen von Ahn'Qiraj",
+            esES = "Ruinas de Ahn'Qiraj",
+            esMX = "Ruinas de Ahn'Qiraj",
+            frFR = "Ruines d’Ahn’Qiraj",
+            itIT = "Ahn'Qiraj Ruins",
+            koKR = "안퀴라즈 폐허",
+            ptBR = "Ruínas de Ahn'Qiraj",
+            ruRU = "Руины Ан'Киража",
+            zhCN = "安其拉废墟",
+            zhTW = "安其拉廢墟",
+        },
+        minLevel = 60,
+        maxLevel = 60,
+        typeID = 2,
+        subtypeID = 0,
+    },
+    [161] = {
+        name = {
+            enUS = "Ahn'Qiraj Temple",
+            deDE = "Tempel von Ahn'Qiraj",
+            esES = "Templo de Ahn'Qiraj",
+            esMX = "Templo de Ahn'Qiraj",
+            frFR = "Temple d’Ahn’Qiraj",
+            itIT = "Ahn'Qiraj Temple",
+            koKR = "안퀴라즈 사원",
+            ptBR = "Templo de Ahn'Qiraj",
+            ruRU = "Храм Ан'Киража",
+            zhCN = "安其拉神殿",
+            zhTW = "安其拉神廟",
+        },
+        minLevel = 60,
+        maxLevel = 60,
+        typeID = 2,
+        subtypeID = 0,
+    },
+    [18] = {
+        name = {
+            enUS = "Scarlet Monastery - Graveyard",
+            deDE = "Scharlachrotes Kloster - Friedhof",
+            esES = "Monasterio Escarlata: Cementerio",
+            esMX = "Monasterio Escarlata - Cementerio",
+            frFR = "Monastère Écarlate - cimetière",
+            itIT = "Scarlet Monastery - Graveyard",
+            koKR = "붉은십자군 수도원 - 묘지",
+            ptBR = "Monastério Escarlate - Cemitério",
+            ruRU = "Монастырь Алого ордена: кладбище",
+            zhCN = "血色修道院 - 墓地",
+            zhTW = "血色修道院 - 墓園",
+        },
+        typeID = 1,
+        subtypeID = 1,
+        maxLevel = 37,
+        minLevel = 29,
+    },
+    [163] = {
+        name = {
+            enUS = "Scarlet Monastery - Armory",
+            deDE = "Scharlachrotes Kloster - Waffenkammer",
+            esES = "Monasterio Escarlata: Armería",
+            esMX = "Monasterio Escarlata - Arsenal",
+            frFR = "Monastère Écarlate - armurerie",
+            itIT = "Scarlet Monastery - Armory",
+            koKR = "붉은십자군 수도원 - 무기고",
+            ptBR = "Monastério Escarlate - Armaria",
+            ruRU = "Монастырь Алого ордена: оружейная",
+            zhCN = "血色修道院 - 军械库",
+            zhTW = "血色修道院 - 軍械庫",
+        },
+        typeID = 1,
+        subtypeID = 1,
+        maxLevel = 42,
+        minLevel = 34,
+    },
+    [164] = {
+        name = {
+            enUS = "Scarlet Monastery - Cathedral",
+            deDE = "Scharlachrotes Kloster - Kathedrale",
+            esES = "Monasterio Escarlata: Catedral",
+            esMX = "Monasterio Escarlata - Catedral",
+            frFR = "Monastère Écarlate - cathédrale",
+            itIT = "Scarlet Monastery - Cathedral",
+            koKR = "붉은십자군 수도원 - 대성당",
+            ptBR = "Monastério Escarlate - Catedral",
+            ruRU = "Монастырь Алого ордена: собор",
+            zhCN = "血色修道院 - 教堂",
+            zhTW = "血色修道院 - 教堂",
+        },
+        typeID = 1,
+        subtypeID = 1,
+        maxLevel = 45,
+        minLevel = 37,
+    },
+    [165] = {
+        name = {
+            enUS = "Scarlet Monastery - Library",
+            deDE = "Scharlachrotes Kloster - Bibliothek",
+            esES = "Monasterio Escarlata: Biblioteca",
+            esMX = "Monasterio Escarlata - Biblioteca",
+            frFR = "Monastère Écarlate - bibliothèque",
+            itIT = "Scarlet Monastery - Library",
+            koKR = "붉은십자군 수도원 - 도서관",
+            ptBR = "Monastério Escarlate - Biblioteca",
+            ruRU = "Монастырь Алого ордена: библиотека",
+            zhCN = "血色修道院 - 图书馆",
+            zhTW = "血色修道院 - 圖書館",
+        },
+        maxLevel = 40,
+        minLevel = 32,
+        typeID = 1,
+        subtypeID = 1
+    },
+    [32] = {
+        -- Note: This DungeonID does not exist in classic client
+        -- We are hijacking it here to put the base "Dire Maul" entry
+        name = {
+            enUS = "Dire Maul",
+            deDE = "Düsterbruch",
+            esES = "La Masacre",
+            esMX = "La Masacre",
+            frFR = "Haches-Tripes",
+            itIT = "Dire Maul",
+            koKR = "혈투의 전장",
+            ptBR = "Gládio Cruel",
+            ruRU = "Забытый город",
+            zhCN = "厄运之槌",
+            zhTW = "厄運之槌",
+        },
+        maxLevel = 63,
+        minLevel = 55,
+        typeID = 1,
+        subtypeID = 1,
+    },
+}
+
+-- hacky solution to manually tack on the dungeon size.
+-- this is only used for the classic era client. since its small enough to hardcode.
+-- `nil` is assumed to be 5
+local dungeonSizes = {
+    -- BGs
+    [53] = 10,  -- WSG
+    [55] = 15,  -- AB
+    [51] = 40,  -- AV
+    -- Dungeons
+    [31] = 10,  -- LBRS
+    [43] = 10,  -- UBRS
+    -- Raids
+    [41] = 20,  -- ZG
+    [160] = 20, -- AQ20
+    [47] = 40,  -- MC
+    [45] = 40,  -- Ony
+    [49] = 40,  -- BWL
+    [161] = 40, -- AQ40
+    [159] = 40, -- Naxx
+}
+
+--- Needed for SoD which has changed some dungeons sizes and level ranges
+local infoOverrides = {
+    -- BFD
+    [9] = isSoD and {
+        typeID = DungeonType.Raid,
+        minLevel = 25,
+        maxLevel = 40,
+        size = 10,
+    },
+    -- Gnomer
+    [13] = isSoD and {
+        typeID = DungeonType.Raid,
+        minLevel = 40,
+        maxLevel = 50,
+        size = 10,
+    },
+    -- ST
+    [27] = isSoD and {
+        typeID = DungeonType.Raid,
+        minLevel = 50,
+        maxLevel = 60,
+        size = 20,
+    },
+}
+
+-- manually associate keys in Tags.lua
+-- this is definately not sustainable outside of classic
+local dungeonCodeByID = {
+    [3] = "RFC",
+    [1] = "WC",
+    [5] = "DEADMINES",
+    [7] = "SFK",
+    [11] = "STK", -- Stocks,
+    [9] = "BFD",
+    [13] = "GNO",
+    [15] = "RFK",
+    [17] = "SM2",   -- base "Scarelet Monestary"
+    [18] = "SMG",   -- GY
+    [163] = "SML",  -- Lib
+    [164] = "SMA",  -- Arm
+    [165] = "SMC",  -- Cath
+    [19] = "RFD",
+    [21] = "ULD",
+    [23] = "ZF",
+    [25] = "MAR",
+    [27] = "ST",
+    [29] = "BRD",
+    [33] = "DM2",  -- Base "Dire Maul" DNE
+    [34] = "DME",
+    [36] = "DMN",
+    [38] = "DMW",
+    [39] = "STR", -- Strat
+    [2] = "SCH",  -- Scholo
+    [31] = "LBRS",
+    [43] = "UBRS",
+    [41] = "ZG",
+    [45] = "ONY",
+    [160] = "AQ20", -- AQ20
+    [47] = "MC",    -- MC
+    [49] = "BWL",   -- BWL
+    [161] = "AQ40", -- AQ40
+    [159] = "NAX",  -- Naxx
+    [53] = "WSG",   -- WSG
+    [55] = "AB",    -- AB
+    [51] = "AV",    -- AV
+}
+
+---@type {[DungeonID]: DungeonInfo}
+local dungeonInfoCache = {}
+do
+    -- only cache dungeons, raids, and battlegrounds
+    local trackedDungeonTypes = {
+        [DungeonType.Dungeon] = true,
+        [DungeonType.Raid] = true,
+        [DungeonType.Battleground] = true,
+    }
+    local function cacheDungeonInfo(dungeonID)
+        local info = {}
+        do
+            local name, typeID, subtypeID, minLevel, maxLevel = GetLFGDungeonInfo(dungeonID);
+            info = {
+                name = name,
+                minLevel = minLevel,
+                maxLevel = maxLevel,
+                typeID = typeID,
+                subtypeID = subtypeID,
+                tagKey = dungeonCodeByID[dungeonID],
+            }
+        end
+        if not info.name then
+            local manualEntry = manualEntries[dungeonID]
+            if manualEntry then
+                info = {
+                    -- default to enUS if locale is missing
+                    name = manualEntry.name[CLIENT_LOCALE] or manualEntry.name.enUS,
+                    typeID = manualEntry.typeID,
+                    subtypeID = manualEntry.subtypeID,
+                    minLevel = manualEntry.minLevel,
+                    maxLevel = manualEntry.maxLevel,
+                }
+            else
+                print(_ .. ": Failed to get dungeon info for ID: " .. dungeonID)
+                return;
+            end
+        end
+        local override = infoOverrides[dungeonID]
+        if override then
+            for k, v in pairs(override) do
+                info[k] = v
+            end
+        end
+        if info.typeID and trackedDungeonTypes[info.typeID] then
+            dungeonInfoCache[dungeonID] = info
+        else
+            print(_ .. ": Skipping dunegeon " .. info.name .. " dungeonID: " .. dungeonID .. " typeID: " .. info.typeID)
+        end
+    end
+    for dungeonID = 1, MAX_DUNGEON_ID do
+        cacheDungeonInfo(dungeonID)
+    end
+end
+
+
+
+local localizedNames -- cache to save some iteration cycles.
+---@return {[DungeonID]: string} # Table mapping `dungeonID` to it's localized name.
+--- Because of holes in the `dungeonID` range, use `pairs` to iterate table.
+function addon.GetClassicLocalizedDungeonNames()
+    if not localizedNames then
+        localizedNames = {}
+        for dungeonID, info in pairs(dungeonInfoCache) do
+            assert(info.name, "Missing name for dungeonID: " .. dungeonID)
+            localizedNames[dungeonID] = info.name
+        end
+    end
+    return localizedNames
+end
+
+local raidCache
+---@return {[DungeonID]: DungeonInfo} # Table mapping `dungeonID` to it's info.
+--- Because of holes in the `dungeonID` range, use `pairs` to iterate table.
+function addon.GetClassicRaids()
+    if not raidCache then
+        raidCache = {}
+        for dungeonID, info in pairs(dungeonInfoCache) do
+            if info.typeID == DungeonType.Raid then
+                raidCache[dungeonID] = CopyTable(info)
+                raidCache[dungeonID].size = dungeonSizes[dungeonID]
+            end
+        end
+    end
+    return raidCache
+end
+
+addon.localizedDungeonIfno = dungeonInfoCache

--- a/LFGBulletinBoard/data/dungeons/classic.lua
+++ b/LFGBulletinBoard/data/dungeons/classic.lua
@@ -281,6 +281,7 @@ local dungeonCodeByID = {
 
 ---@type {[DungeonID]: DungeonInfo}
 local dungeonInfoCache = {}
+local numDungeons = 0
 do
     -- only cache dungeons, raids, and battlegrounds
     local trackedDungeonTypes = {
@@ -325,6 +326,7 @@ do
         end
         if info.typeID and trackedDungeonTypes[info.typeID] then
             dungeonInfoCache[dungeonID] = info
+            numDungeons = numDungeons + 1
         else
             print(_ .. ": Skipping dunegeon " .. info.name .. " dungeonID: " .. dungeonID .. " typeID: " .. info.typeID)
         end
@@ -370,4 +372,7 @@ function addon.GetClassicDungeonCodes()
     return dunegeonIDByCode
 end
 
+function addon.GetNumClassicDungeons()
+    return numDungeons
+end
 addon.localizedDungeonInfo = dungeonInfoCache

--- a/LFGBulletinBoard/data/dungeons/classic.lua
+++ b/LFGBulletinBoard/data/dungeons/classic.lua
@@ -3,6 +3,10 @@ local _, addon = ...
 -- exists in classic even though no Dungeon Finder.
 assert(GetLFGDungeonInfo, _ .. " requires the API `GetLFGDungeonInfo` for parsing dungeon info")
 
+-- intialize here for now, this should be moved to a file thats always grunteed to load first.
+---@class AddonEnum
+addon.Enum = {} 
+
 ---@enum DungeonTypeID
 local DungeonType = {
     Dungeon = 1,
@@ -390,4 +394,6 @@ function addon.GetClassicDungeonInfo(dungeonID)
         return CopyTable(dungeonInfoCache)
     end
 end
+
 addon.localizedDungeonInfo = dungeonInfoCache
+addon.Enum.DungeonType = DungeonType

--- a/LFGBulletinBoard/data/dungeons/classic.lua
+++ b/LFGBulletinBoard/data/dungeons/classic.lua
@@ -1,5 +1,6 @@
 local _, addon = ...
 
+if WOW_PROJECT_ID ~= WOW_PROJECT_CLASSIC then return end
 -- exists in classic even though no Dungeon Finder.
 assert(GetLFGDungeonInfo, _ .. " requires the API `GetLFGDungeonInfo` for parsing dungeon info")
 

--- a/LFGBulletinBoard/data/dungeons/wrath.lua
+++ b/LFGBulletinBoard/data/dungeons/wrath.lua
@@ -1,0 +1,830 @@
+-- this file is here to keep old methods from breaking interim
+-- it will be updated in the future
+
+local TOCNAME,GBB=...
+
+local function getSeasonalDungeons()
+    local events = {}
+
+    for eventName, eventData in pairs(GBB.Seasonal) do
+		table.insert(events, eventName)
+        if GBB.Tool.InDateRange(eventData.startDate, eventData.endDate) then
+			GBB.SeasonalActiveEvents[eventName] = true
+        end
+    end
+	return events
+end
+
+local function getPvpByVersion()
+	local version, build, date, tocversion = GetBuildInfo()
+	if string.sub(version, 1, 2) ~= "1." then
+		return GBB.PvpNames
+	end
+	return GBB.PvpSodNames
+end
+
+function GBB.GetDungeonNames()
+	local DefaultEnGB={
+		["RFC"] = 	"Ragefire Chasm",
+		["DM"] = 	"The Deadmines",
+		["WC"] = 	"Wailing Caverns",
+		["SFK"] = 	"Shadowfang Keep",
+		["STK"] = 	"The Stockade",
+		["BFD"] = 	"Blackfathom Deeps",
+		["GNO"] = 	"Gnomeregan",
+		["RFK"] = 	"Razorfen Kraul",
+		["SM2"] =	"Scarlet Monastery",
+		["SMG"] = 	"Scarlet Monastery: Graveyard",
+		["SML"] = 	"Scarlet Monastery: Library",
+		["SMA"] = 	"Scarlet Monastery: Armory",
+		["SMC"] = 	"Scarlet Monastery: Cathedral",
+		["RFD"] = 	"Razorfen Downs",
+		["ULD"] = 	"Uldaman",
+		["ZF"] = 	"Zul'Farrak",
+		["MAR"] = 	"Maraudon",
+		["ST"] = 	"The Sunken Temple",
+		["BRD"] = 	"Blackrock Depths",
+		["DM2"] = 	"Dire Maul",
+		["DME"] = 	"Dire Maul: East",
+		["DMN"] = 	"Dire Maul: North",
+		["DMW"] = 	"Dire Maul: West",
+		["STR"] = 	"Stratholme",
+		["SCH"] = 	"Scholomance",
+		["LBRS"] = 	"Lower Blackrock Spire",
+		["UBRS"] = 	"Upper Blackrock Spire (10)",
+		["RAMPS"] = "Hellfire Citadel: Ramparts",
+		["BF"] = 	"Hellfire Citadel: Blood Furnace",
+		["SP"] = 	"Coilfang Reservoir: Slave Pens",
+		["UB"] = 	"Coilfang Reservoir: Underbog",
+		["MT"] = 	"Auchindoun: Mana Tombs",
+		["CRYPTS"] = "Auchindoun: Auchenai Crypts",
+		["SETH"] = 	"Auchindoun: Sethekk Halls",
+		["OHB"] = 	"Caverns of Time: Old Hillsbrad",
+		["MECH"] = 	"Tempest Keep: The Mechanar",
+		["BM"] = 	"Caverns of Time: Black Morass",
+		["MGT"] = 	"Magisters' Terrace",
+		["SH"] = 	"Hellfire Citadel: Shattered Halls",
+		["BOT"] = 	"Tempest Keep: Botanica",
+		["SL"] = 	"Auchindoun: Shadow Labyrinth",
+		["SV"] = 	"Coilfang Reservoir: Steamvault",
+		["ARC"] = 	"Tempest Keep: The Arcatraz",
+		["KARA"] = 	"Karazhan",
+		["GL"] = 	"Gruul's Lair",
+		["MAG"] = 	"Hellfire Citadel: Magtheridon's Lair",
+		["SSC"] = 	"Coilfang Reservoir: Serpentshrine Cavern",
+
+		["UK"] = 	"Utgarde Keep",
+		["NEX"] = 	"The Nexus",
+		["AZN"] = 	"Azjol-Nerub",
+		["ANK"] = 	"Ahn’kahet: The Old Kingdom",
+		["DTK"] = 	"Drak’Tharon Keep",
+		["VH"] = 	"Violet Hold",
+		["GD"] = 	"Gundrak",
+		["HOS"] = 	"Halls of Stone",
+		["HOL"] = 	"Halls of Lightning",
+		["COS"] = 	"The Culling of Stratholme",
+		["OCC"] = 	"The Oculus",
+		["UP"] = 	"Utgarde Pinnacle",
+		["FOS"] = 	"Forge of Souls",
+		["POS"] = 	"Pit of Saron",
+		["HOR"] = 	"Halls of Reflection",
+		["CHAMP"] = "Trial of the Champion",
+		["NAXX"] = 	"Naxxramas",
+
+		["OS"]   =  "Obsidian Sanctum",
+		["VOA"] = 	"Vault of Archavon",
+		["EOE"] = 	"Eye of Eternity",
+		["ULDAR"] =   "Ulduar",
+		["TOTC"] = 	"Trial of the Crusader",
+		["RS"] = 	"Ruby Sanctum",
+		["ICC"] = 	"Icecrown Citadel",
+
+		["EYE"] = 	"Tempest Keep: The Eye",
+		["ZA"] = 	"Zul-Aman",
+		["HYJAL"] = "The Battle For Mount Hyjal",
+		["BT"] = 	"Black Temple",
+		["SWP"] = 	"Sunwell Plateau",
+		["ONY"] = 	"Onyxia's Lair (40)",
+		["MC"] = 	"Molten Core (40)",
+		["ZG"] = 	"Zul'Gurub (20)",
+		["AQ20"] = 	"Ruins of Ahn'Qiraj (20)",
+		["BWL"] = 	"Blackwing Lair (40)",
+		["AQ40"] = 	"Temple of Ahn'Qiraj (40)",
+		["NAX"] = 	"Naxxramas (40)",
+		["WSG"] = 	"Warsong Gulch (PvP)",
+		["AB"] = 	"Arathi Basin (PvP)",
+		["AV"] = 	"Alterac Valley (PvP)",
+		["EOTS"] =  "Eye of the Storm (PvP)",
+		["SOTA"] =   "Stand of the Ancients (PvP)",
+		["WG"]  =   "Wintergrasp (PvP)",
+		["ARENA"] = "Arena (PvP)",
+		["MISC"] = 	"Miscellaneous",
+		["TRADE"] =	"Trade",
+		["DEBUG"] = "DEBUG INFO",
+		["BAD"] =	"DEBUG BAD WORDS - REJECTED",
+		["BREW"] =  "Brewfest - Coren Direbrew",
+		["HOLLOW"] =  "Hallow's End - Headless Horseman",
+    	["TRAVEL"] = "Travel services - Summons/Portals",
+		["BLOOD"] = "Bloodmoon",
+		["INCUR"] = "Incursions",
+		}
+
+	local dungeonNamesLocales={
+		deDE ={
+			["RFC"] = 	"Flammenschlund",
+			["DM"] = 	"Die Todesminen",
+			["WC"] = 	"Die Höhlen des Wehklagens",
+			["SFK"] = 	"Burg Schattenfang",
+			["STK"] = 	"Das Verlies",
+			["BFD"] = 	"Die Tiefschwarze Grotte",
+			["GNO"] = 	"Gnomeregan",
+			["RFK"] = 	"Kral der Klingenhauer",
+			["SM2"] =	"Scharlachrotes Kloster",
+			["SMG"] = 	"Scharlachrotes Kloster: Friedhof",
+			["SML"] = 	"Scharlachrotes Kloster: Bibliothek",
+			["SMA"] = 	"Scharlachrotes Kloster: Waffenkammer",
+			["SMC"] = 	"Scharlachrotes Kloster: Kathedrale",
+			["RFD"] = 	"Hügel der Klingenhauer",
+			["ULD"] = 	"Uldaman",
+			["ZF"] = 	"Zul'Farrak",
+			["MAR"] = 	"Maraudon",
+			["ST"] = 	"Der Tempel von Atal'Hakkar",
+			["BRD"] = 	"Die Schwarzfels-Tiefen",
+			["DM2"] = 	"Düsterbruch",
+			["DME"] = 	"Düsterbruch: Ost",
+			["DMN"] = 	"Düsterbruch: Nord",
+			["DMW"] = 	"Düsterbruch: West",
+			["STR"] = 	"Stratholme",
+			["SCH"] = 	"Scholomance",
+			["LBRS"] = 	"Die Untere Schwarzfelsspitze",
+			["UBRS"] = 	"Obere Schwarzfelsspitze (10)",
+			["RAMPS"] = "Höllenfeuerzitadelle: Höllenfeuerbollwerk",
+			["BF"] = 	"Höllenfeuerzitadelle: Der Blutkessel",
+			["SP"] = 	"Echsenkessel: Die Sklavenunterkünfte",
+			["UB"] = 	"Echsenkessel: Der Tiefensumpf",
+			["MT"] = 	"Auchindoun: Die Managruft",
+			["CRYPTS"] = "Auchindoun: Die Auchenaikrypta",
+			["SETH"] = 	"Auchindoun: Sethekkhallen",
+			["OHB"] = 	"Höhlen der Zeit: Flucht von Durnholde",
+			["MECH"] = 	"Festung der Stürme: Die Mechanar",
+			["BM"] = 	"Höhlen der Zeit: Der Schwarze Morast",
+			["MGT"] = 	"Die Terrasse der Magister",
+			["SH"] = 	"Höllenfeuerzitadelle: Die Zerschmetterten Hallen",
+			["BOT"] = 	"Festung der Stürme: Botanica",
+			["SL"] = 	"Auchindoun: Schattenlabyrinth",
+			["SV"] = 	"Echsenkessel: Die Dampfkammer",
+			["ARC"] = 	"Festung der Stürme: Die Arcatraz",
+			["KARA"] = 	"Karazhan",
+			["GL"] = 	"Gruuls Unterschlupf",
+			["MAG"] = 	"Höllenfeuerzitadelle: Magtheridons Kammer",
+			["SSC"] = 	"Echsenkessel: Höhle des Schlangenschreins",
+			["EYE"] = 	"Das Auge des Sturms",
+			["ZA"] = 	"Zul-Aman",
+			["HYJAL"] = "Schlacht um den Berg Hyjal",
+			["BT"] = 	"Der Schwarze Tempel",
+			["SWP"] = 	"Sonnenbrunnenplateau",
+			["ONY"] = 	"Onyxias Hort (40)",
+			["MC"] = 	"Geschmolzener Kern (40)",
+			["ZG"] = 	"Zul'Gurub (20)",
+			["AQ20"] = 	"Ruinen von Ahn'Qiraj (20)",
+			["BWL"] = 	"Pechschwingenhort (40)",
+			["AQ40"] = 	"Tempel von Ahn'Qiraj (40)",
+			["NAX"] = 	"Naxxramas (40)",
+			["WSG"] = 	"Warsongschlucht (PVP)",
+			["AV"] = 	"Alteractal (PVP)",
+			["AB"] = 	"Arathibecken (PVP)",
+			["EOTS"] =  "Auge des Sturms (PvP)",
+			["ARENA"] = "Arena (PvP)",
+			["MISC"] = 	"Verschiedenes",
+			["TRADE"] =	"Handel",
+
+		},
+		frFR ={
+    ["RFC"] = 	"Gouffre de Ragefeu",
+    ["DM"] = 	"Les Mortemines",
+    ["WC"] = 	"Cavernes des lamentations",
+    ["SFK"] = 	"Donjon d'Ombrecroc",
+    ["STK"] = 	"La Prison",
+    ["BFD"] = 	"Profondeurs de Brassenoire",
+    ["GNO"] = 	"Gnomeregan",
+    ["RFK"] = 	"Kraal de Tranchebauge",
+    ["SM2"] =	"Monastère écarlate",
+    ["SMG"] = 	"Monastère écarlate: Cimetière",
+    ["SML"] = 	"Monastère écarlate: Bibliothèque",
+    ["SMA"] = 	"Monastère écarlate: Armurerie",
+    ["SMC"] = 	"Monastère écarlate: Cathédrale",
+    ["RFD"] = 	"Souilles de Tranchebauge",
+    ["ULD"] = 	"Uldaman",
+    ["ZF"] = 	"Zul'Farrak",
+    ["MAR"] = 	"Maraudon",
+    ["ST"] = 	"Le temple d'Atal'Hakkar",
+    ["BRD"] = 	"Profondeurs de Blackrock",
+    ["DM2"] = 	"Hache-tripes",
+    ["DME"] = 	"Hache-tripes: Est",
+    ["DMN"] = 	"Hache-tripes: Nord",
+    ["DMW"] = 	"Hache-tripes: Ouest",
+    ["STR"] = 	"Stratholme",
+    ["SCH"] = 	"Scholomance",
+    ["LBRS"] = 	"Pic Blackrock",
+    ["UBRS"] = 	"Pic Blackrock (10)",
+    ["RAMPS"] = "Citadelle des Flammes Infernales: Remparts des Flammes infernales",
+    ["BF"] = 	"Citadelle des Flammes Infernales: La Fournaise du sang",
+    ["SP"] = 	"Réservoir de Glissecroc : Les enclos aux esclaves",
+    ["UB"] = 	"Réservoir de Glissecroc : La Basse-tourbière",
+    ["MT"] = 	"Auchindoun: Tombes-mana",
+    ["CRYPTS"] = "Auchindoun: Cryptes Auchenaï",
+    ["SETH"] = 	"Auchindoun: Les salles des Sethekk",
+    ["OHB"] = 	"Grottes du Temps: Contreforts de Hautebrande d'antan",
+    ["MECH"] = 	"Donjon de la Tempête: Le Méchanar",
+    ["BM"] = 	"Grottes du Temps: Le Noir Marécage",
+    ["MGT"] = 	"Terrasse des Magistères",
+    ["SH"] = 	"Citadelle des Flammes Infernales: Les Salles brisées",
+    ["BOT"] = 	"Donjon de la Tempête: Botanica",
+    ["SL"] = 	"Auchindoun: Labyrinthe des ombres",
+    ["SV"] = 	"Réservoir de Glissecroc : Le Caveau de la vapeur",
+    ["ARC"] = 	"Donjon de la Tempête: L'Arcatraz",
+    ["KARA"] = 	"Karazhan",
+    ["GL"] = 	"Repaire de Gruul",
+    ["MAG"] = 	"Citadelle des Flammes Infernales: Le repaire de Magtheridon",
+    ["SSC"] = 	"Réservoir de Glissecroc : Caverne du sanctuaire du Serpent",
+    ["EYE"] = 	"Donjon de la Tempête : L'Oeil",
+    ["ZA"] = 	"Zul-Aman",
+    ["HYJAL"] = "Sommet d'Hyjal",
+    ["BT"] = 	"Temple noir",
+    ["SWP"] = 	"Plateau du Puits de soleil",
+    ["ONY"] = 	"Repaire d'Onyxia (40)",
+    ["MC"] = 	"Cœur du Magma (40)",
+    ["ZG"] = 	"Zul'Gurub (20)",
+    ["AQ20"] = 	"Ruines d'Ahn'Qiraj (20)",
+    ["BWL"] = 	"Repaire de l'Aile noire (40)",
+    ["AQ40"] = 	"Ahn'Qiraj (40)",
+    ["NAX"] = 	"Naxxramas (40)",
+    ["ARENA"] = "Arène (PvP)",
+    ["AB"] = "Bassin d'Arathi (PvP)",
+    ["ANK"] = "Ahn'kahet, l'Ancien royaume",
+    ["AV"] = "Vallée d'Alterac (PvP)",
+    ["AZN"] = "Azjol-Nérub",
+    ["BREW"] = "Fete des brasseurs - Coren Navrebière",
+    ["CHAMP"] = "L'épreuve du champion",
+    ["COS"] = "L'Épuration de Stratholme",
+    ["DEBUG"] = "DEBUG",
+    ["DTK"] = "Donjon de Drak'Tharon",
+    ["EOE"] = "L'Oeil de l'éternité",
+    ["EOTS"] = "L'Oeil du cyclone (PvP)",
+    ["FOS"] = "La Forge des âmes",
+    ["GD"] = "Gundrak",
+    ["HOL"] = "Les salles de Foudre",
+    ["HOLLOW"] = "Sanssaint - Cavalier sans tête",
+    ["HOR"] = "Salles des Reflets",
+    ["HOS"] = "Les salles de Pierre",
+    ["MISC"] = "Divers",
+    ["NEX"] = "Le Nexus",
+    ["OCC"] = "L'Oculus",
+    ["OS"] = "Le sanctum Obsidien",
+    ["POS"] = "Fosse de Saron",
+    ["RS"] = "Le sanctum Rubis",
+    ["SOTA"] = "Rivage des Anciens (PvP)",
+    ["TOTC"] = "L'épreuve du croisé",
+    ["TRADE"] = "Commerce",
+    ["UK"] = "Donjon d'Utgarde",
+    ["ULDAR"] = "Ulduar",
+    ["UP"] = "Cime d'Utgarde",
+    ["VH"] = "Le fort Pourpre",
+    ["VOA"] = "Caveau d'Archavon",
+    ["WG"] = "Joug-d'hiver",
+    ["WSG"] = "Goulet des Chanteguerres (PvP)", 
+		},
+		esMX ={
+			["RFC"] = 	"Sima Ígnea",
+			["DM"] = 	"Las Minas de la Muerte",
+			["WC"] = 	"Cuevas de los Lamentos",
+			["SFK"] = 	"Castillo de Colmillo Oscuro",
+			["STK"] = 	"Las Mazmorras",
+			["BFD"] = 	"Cavernas de Brazanegra",
+			["GNO"] = 	"Gnomeregan",
+			["RFK"] = 	"Horado Rajacieno",
+			["SM2"] =	"Monasterio Escarlata",
+			["SMG"] = 	"Monasterio Escarlata: Friedhof",
+			["SML"] = 	"Monasterio Escarlata: Bibliothek",
+			["SMA"] = 	"Monasterio Escarlata: Waffenkammer",
+			["SMC"] = 	"Monasterio Escarlata: Kathedrale",
+			["RFD"] = 	"Zahúrda Rojocieno",
+			["ULD"] = 	"Uldaman",
+			["ZF"] = 	"Zul'Farrak",
+			["MAR"] = 	"Maraudon",
+			["ST"] = 	"El Templo de Atal'Hakkar",
+			["BRD"] = 	"Profundidades de Roca Negra	",
+			["DM2"] = 	"La Masacre",
+			["DME"] = 	"La Masacre: Ost",
+			["DMN"] = 	"La Masacre: Nord",
+			["DMW"] = 	"La Masacre: West",
+			["STR"] = 	"Stratholme",
+			["SCH"] = 	"Scholomance",
+			["LBRS"] = 	"Cumbre de Roca Negra",
+			["UBRS"] = 	"Cumbre de Roca Negra (10)",
+			["RAMPS"] = "Hellfire Citadel: Ramparts",
+			["BF"] = 	"Hellfire Citadel: Blood Furnace",
+			["SP"] = 	"Coilfang Reservoir: Slave Pens",
+			["UB"] = 	"Coilfang Reservoir: Underbog",
+			["MT"] = 	"Auchindoun: Mana Tombs",
+			["CRYPTS"] = "Auchindoun: Auchenai Crypts",
+			["SETH"] = 	"Auchindoun: Sethekk Halls",
+			["OHB"] = 	"Caverns of Time: Old Hillsbrad",
+			["MECH"] = 	"Tempest Keep: The Mechanar",
+			["BM"] = 	"Caverns of Time: Black Morass",
+			["MGT"] = 	"Magisters' Terrace",
+			["SH"] = 	"Hellfire Citadel: Shattered Halls",
+			["BOT"] = 	"Tempest Keep: Botanica",
+			["SL"] = 	"Auchindoun: Shadow Labyrinth",
+			["SV"] = 	"Coilfang Reservoir: Steamvault",
+			["ARC"] = 	"Tempest Keep: The Arcatraz",
+			["KARA"] = 	"Karazhan",
+			["GL"] = 	"Gruul's Lair",
+			["MAG"] = 	"Hellfire Citadel: Magtheridon's Lair",
+			["SSC"] = 	"Coilfang Reservoir: Serpentshrine Cavern",
+			["EYE"] = 	"The Eye",
+			["ZA"] = 	"Zul-Aman",
+			["HYJAL"] = "The Battle For Mount Hyjal",
+			["BT"] = 	"Black Temple",
+			["SWP"] = 	"Sunwell Plateau",
+			["ONY"] = 	"Guarida de Onyxia (40)",
+			["MC"] = 	"Núcleo de Magma (40)",
+			["ZG"] = 	"Zul'Gurub (20)",
+			["AQ20"] = 	"Ruinas de Ahn'Qiraj (20)",
+			["BWL"] = 	"Guarida Alanegra (40)",
+			["AQ40"] = 	"Ahn'Qiraj (40)",
+			["NAX"] = 	"Naxxramas (40)",
+			["ARENA"] = "Arena (PvP)",
+
+		},
+		ruRU = {
+			["AB"] = "Низина Арати (PvP)",
+			["ANK"] = "Ан'кахет: Старое Королевство",
+			["AQ20"] = "Руины Ан'Киража (20)",
+			["AQ40"] = "Ан'Кираж (40)",
+			["ARC"] = "Крепость Бурь: Аркатрац",
+			["ARENA"] = "Арена (PvP)",
+			["AV"] = "Альтеракская Долина (PvP)",
+			["AZN"] = "Азжол-Неруб",
+			["BAD"] = "ОТЛАДКА ПЛОХИЕ СЛОВА - ОТКЛОНЕН",
+			["BF"] = "Цитадель Адского Пламени: Кузня Крови",
+			["BFD"] = "Непроглядная Пучина",
+			["BM"] = "Пещеры Времени: Черные топи",
+			["BOT"] = "Крепость Бурь: Ботаника",
+			["BRD"] = "Глубины Черной горы",
+			["BREW"] = "Хмельной фестиваль - Корен Худовар",
+			["BT"] = "Черный Храм",
+			["BWL"] = "Логово Крыла Тьмы (40)",
+			["CHAMP"] = "Испытание Чемпиона",
+			["COS"] = "Очищение Стратхольма",
+			["CRYPTS"] = "Аукиндон: Аукенайские гробницы",
+			["DEBUG"] = "ИНФОРМАЦИЯ О ОТЛАДКАХ",
+			["DM"] = "Мертвые копи",
+			["DM2"] = "Забытый Город",
+			["DME"] = "Забытый Город: Восток",
+			["DMN"] = "Забытый Город: Север",
+			["DMW"] = "Забытый Город: Запад",
+			["DTK"] = "Крепость Драк'Тарон",
+			["EOE"] = "Око Вечности",
+			["EOTS"] = "Око Бури (PvP)",
+			["EYE"] = "Крепость Бурь: Око",
+			["FOS"] = "Кузня Душ",
+			["GD"] = "Гундрак",
+			["GL"] = "Логово Груула",
+			["GNO"] = "Гномреган",
+			["HOL"] = "Чертоги Молний",
+			["HOLLOW"] = "Тыквовин - Всадник без головы",
+			["HOR"] = "Залы Отражений",
+			["HOS"] = "Чертоги Камня",
+			["HYJAL"] = "Пещеры Времени: Вершина Хиджала",
+			["ICC"] = "Цитадель Ледяной Короны",
+			["KARA"] = "Каражан",
+			["LBRS"] = "Низ Вершины Черной горы",
+			["MAG"] = "Цитадель Адского Пламени: Логово Магтеридона",
+			["MAR"] = "Мародон",
+			["MC"] = "Огненные Недра (40)",
+			["MECH"] = "Крепость Бурь: Механар",
+			["MGT"] = "Терраса магистров",
+			["MISC"] = "Прочее",
+			["MT"] = "Аукиндон: Гробницы Маны",
+			["NAX"] = "Наксрамас (40)",
+			["NAXX"] = "Наксрамас",
+			["NEX"] = "Нексус",
+			["OCC"] = "Окулус",
+			["OHB"] = "Пещеры Времени: Старые предгорья Хилсбрада",
+			["ONY"] = "Логово Ониксии (40)",
+			["OS"] = "Обсидиановое святилище",
+			["POS"] = "Яма Сарона",
+			["RAMPS"] = "Цитадель Адского Пламени: Бастионы",
+			["RFC"] = "Огненная пропасть",
+			["RFD"] = "Курганы Иглошкурых",
+			["RFK"] = "Лабиринты Иглошкурых",
+			["RS"] = "Рубиновое Святилище",
+			["SCH"] = "Некроситет",
+			["SETH"] = "Аукиндон: Сетеккские залы",
+			["SFK"] = "Крепость Темного Клыка",
+			["SH"] = "Цитадель Адского Пламени: Разрушенные залы",
+			["SL"] = "Аукиндон: Темный лабиринт",
+			["SM2"] = "Монастырь Алого ордена",
+			["SMA"] = "Монастырь Алого ордена: Оружейная",
+			["SMC"] = "Монастырь Алого ордена: Собор",
+			["SMG"] = "Монастырь Алого ордена: Кладбище",
+			["SML"] = "Монастырь Алого ордена: Библиотека",
+			["SOTA"] = "Берег Древних (PvP)",
+			["SP"] = "Резервуар Кривого Клыка: Узилище",
+			["SSC"] = "Резервуар Кривого Клыка: Змеиное святилище",
+			["ST"] = "Затонувший Храм",
+			["STK"] = "Тюрьма",
+			["STR"] = "Стратхольм",
+			["SV"] = "Резервуар Кривого Клыка: Паровое подземелье",
+			["SWP"] = "Плато Солнечного Колодца",
+			["TOTC"] = "Испытание Крестоносца",
+			["TRADE"] = "Торговля",
+			["UB"] = "Резервуар Кривого Клыка: Нижетопь",
+			["UBRS"] = "Верх Вершины Черной горы (10)",
+			["UK"] = "Крепость Утгард",
+			["ULD"] = "Ульдаман",
+			["ULDAR"] = "Ульдуар",
+			["UP"] = "Вершина Утгард",
+			["VH"] = "Аметистовая крепость",
+			["VOA"] = "Склеп Аркавона",
+			["WC"] = "Пещеры Стенаний",
+			["WG"] = "Озеро ледяных оков (PvP)",
+			["WSG"] = "Ущелье Песни Войны (PvP)",
+			["ZA"] = "Зул'Аман",
+			["ZF"] = "Зул'Фаррак",
+			["ZG"] = "Зул'Гуруб (20)",
+		},
+		zhTW ={
+			["RFC"] = 	"怒焰裂谷",
+			["DM"] = 	"死亡礦坑",
+			["WC"] = 	"哀嚎洞穴",
+			["SFK"] = 	"影牙城堡",
+			["STK"] = 	"監獄",
+			["BFD"] = 	"黑暗深淵",
+			["GNO"] = 	"諾姆瑞根",
+			["RFK"] = 	"剃刀沼澤",
+			["SM2"] =	"血色修道院",
+			["SMG"] = 	"血色修道院: 墓地",
+			["SML"] = 	"血色修道院: 圖書館",
+			["SMA"] = 	"血色修道院: 軍械庫",
+			["SMC"] = 	"血色修道院: 大教堂",
+			["RFD"] = 	"剃刀高地",
+			["ULD"] = 	"奧達曼",
+			["ZF"] = 	"祖爾法拉克",
+			["MAR"] = 	"瑪拉頓",
+			["ST"] = 	"阿塔哈卡神廟",
+			["BRD"] = 	"黑石深淵",
+			["DM2"] = 	"厄運之槌",
+			["DME"] = 	"厄運之槌: 東",
+			["DMN"] = 	"厄運之槌: 北",
+			["DMW"] = 	"厄運之槌: 西",
+			["STR"] = 	"斯坦索姆",
+			["SCH"] = 	"通靈學院",
+			["LBRS"] = 	"黑石塔下層",
+			["UBRS"] = 	"黑石塔上層 (10)",
+			["RAMPS"] = 	"地獄火壁壘",
+			["BF"] = 	"血熔爐",
+			["SP"] = 	"奴隸監獄",
+			["UB"] = 	"深幽泥沼",
+			["MT"] = 	"法力墓地",
+			["CRYPTS"] = 	"奧奇奈地穴",
+			["SETH"] = 	"塞司克大廳",
+			["OHB"] = 	"希爾斯布萊德丘陵舊址",
+			["MECH"] = 	"麥克納爾",
+			["BM"] = 	"黑色沼澤",
+			["MGT"] = 	"博學者殿堂",
+			["SH"] = 	"破碎大廳",
+			["BOT"] = 	"波塔尼卡",
+			["SL"] = 	"暗影迷宮",
+			["SV"] = 	"蒸氣洞穴",
+			["ARC"] = 	"亞克崔茲",
+			["KARA"] = 	"卡拉贊 (10)",
+			["GL"] = 	"戈魯爾之巢 (25)",
+			["MAG"] = 	"瑪瑟里頓的巢穴 (25)",
+			["SSC"] = 	"毒蛇神殿洞穴 (25)",
+			["EYE"] = 	"風暴要塞 (25)",
+			["ZA"] = 	"祖阿曼 (10)",
+			["HYJAL"] = 	"海加爾山 (25)",
+			["BT"] = 	"黑暗神廟 (25)",
+			["SWP"] = 	"太陽之井高地 (25)",
+			["ONY"] = 	"奧妮克希亞的巢穴 (40)",
+			["MC"] = 	"熔火之心 (40)",
+			["ZG"] = 	"祖爾格拉布 (20)",
+			["AQ20"] = 	"安其拉廢墟 (20)",
+			["BWL"] = 	"黑翼之巢 (40)",
+			["AQ40"] = 	"安其拉 (40)",
+			["NAX"] = 	"納克薩瑪斯 (40)",
+			["WSG"] = 	"戰歌峽谷 (PvP)",
+			["AB"] = 	"阿拉希盆地 (PvP)",
+			["AV"] = 	"奧特蘭克山谷 (PvP)",
+			["EOTS"] = 	"暴風之眼 (PvP)",
+			["MISC"] = 	"未分類",
+			["TRADE"] =	"交易",
+		},
+		zhCN ={
+			["UK"] = 	"乌特加德城堡",
+			["NEX"] = 	"魔枢",
+			["AZN"] = 	"艾卓",
+			["ANK"] = 	"安卡赫特：古代王国",
+			["DTK"] = 	"达克萨隆要塞",
+			["VH"] = 	"紫罗兰监狱",
+			["GD"] = 	"古达克",
+			["HOS"] = 	"岩石大厅",
+			["HOL"] = 	"闪电大厅",
+			["COS"] = 	"净化斯坦索姆",
+			["OCC"] = 	"魔环",
+			["UP"] = 	"乌特加德之巅",
+			["FOS"] = 	"灵魂洪炉",
+			["POS"] = 	"萨隆深渊",
+			["HOR"] = 	"映像大厅",
+			["CHAMP"] = "冠军的试炼",
+			["NAXX"] = 	"纳克萨玛斯80",
+
+			["OS"]   =  "黑曜石圣殿 红龙",
+			["VOA"] = 	"阿尔卡冯的宝库",
+			["EOE"] = 	"永恒之眼 蓝龙",
+			["ULDAR"] = "奥杜尔",
+			["TOTC"] = 	"十字军的试炼",
+			["RS"] = 	"红玉圣殿",
+			["ICC"] = 	"冰冠碉堡",
+
+			["RFC"] = 	"怒焰峡谷",
+			["DM"] = 	"死亡矿坑",
+			["WC"] = 	"哀嚎洞穴",
+			["SFK"] = 	"影牙城堡",
+			["STK"] = 	"监狱",
+			["BFD"] = 	"黑暗深渊",
+			["GNO"] =  	"诺莫瑞根" ,
+			["RFK"] = 	"剃刀沼泽",
+			["SM2"] =	"血色修道院",
+			["SMG"] = 	"血色修道院: 墓地",
+			["SML"] = 	"血色修道院: 图书馆",
+			["SMA"] = 	"血色修道院: 武器库",
+			["SMC"] = 	"血色修道院: 教堂",
+			["RFD"] = 	"剃刀高地",
+			["ULD"] = 	"奥达曼",
+			["ZF"] = 	"祖尔法拉克",
+			["MAR"] = 	"玛拉顿",
+			["ST"] = 	"沉默的神庙",
+			["BRD"] = 	"黑石深渊",
+			["DM2"] = 	"厄运之槌",
+			["DME"] = 	"厄運之槌: 东",
+			["DMN"] = 	"厄運之槌: 北",
+			["DMW"] = 	"厄運之槌: 西",
+			["STR"] = 	"斯坦索姆",
+			["SCH"] = 	"通灵學院",
+			["LBRS"] = 	"黑石塔下层",
+			["UBRS"] = 	"黑石塔上层 (10)",
+			["RAMPS"] = "地狱火城墙",
+			["BF"] = 	"献血熔炉",
+			["SP"] = 	"奴隶围栏",
+			["UB"] = 	"幽暗沼泽",
+			["MT"] = 	"法力陵墓",
+			["CRYPTS"] = "奥金尼地穴",
+			["SETH"] = 	"塞泰克大厅",
+			["OHB"] = 	"旧希尔斯布莱德丘陵",
+			["MECH"] = 	"能源舰",
+			["BM"] = 	"黑色沼泽",
+			["MGT"] = 	"魔导师平台",
+			["SH"] = 	"破碎大厅",
+			["BOT"] = 	"生态船",
+			["SL"] = 	"暗影迷宮",
+			["SV"] = 	"蒸汽地窖",
+			["ARC"] = 	"禁魔监狱",
+			["KARA"] = 	"卡拉赞 (10)",
+			["GL"] = 	"格鲁尔之巢 (25)",
+			["MAG"] = 	"玛瑟里顿的巢穴 (25)",
+			["SSC"] = 	"毒蛇神殿 (25)",
+			["EYE"] = 	"风暴要塞 (25)",
+			["ZA"] = 	"祖阿曼 (10)",
+			["HYJAL"] = "海加尔山 (25)",
+			["BT"] = 	"黑暗神庙 (25)",
+			["SWP"] = 	"太阳之井高地 (25)",
+			["ONY"] = 	"奧妮克希亞的巢穴 (40)",
+			["MC"] = 	"熔火之心 (40)",
+			["ZG"] = 	"祖尔格拉布 (20)",
+			["AQ20"] = 	"安其拉废墟 (20)",
+			["BWL"] = 	"黑翼之巢 (40)",
+			["AQ40"] = 	"安其拉 (40)",
+			["NAX"] = 	"纳克萨玛斯 (40)",
+			["WSG"] = 	"战歌峽谷 (PvP)",
+			["AB"] = 	"阿拉希盆地 (PvP)",
+			["AV"] = 	"奧特兰克山谷 (PvP)",
+			["EOTS"] = 	"风暴之眼 (PvP)",
+			["MISC"] = 	"未分類",
+			["TRADE"] =	"交易",
+		},
+	}
+
+
+
+	local dungeonNames = dungeonNamesLocales[GetLocale()] or {}
+
+	if GroupBulletinBoardDB and GroupBulletinBoardDB.CustomLocalesDungeon and type(GroupBulletinBoardDB.CustomLocalesDungeon) == "table" then
+		for key,value in pairs(GroupBulletinBoardDB.CustomLocalesDungeon) do
+			if value~=nil and value ~="" then
+				dungeonNames[key.."_org"]=dungeonNames[key] or DefaultEnGB[key]
+				dungeonNames[key]=value
+			end
+		end
+	end
+
+
+	setmetatable(dungeonNames, {__index = DefaultEnGB})
+
+	dungeonNames["DEADMINES"]=dungeonNames["DM"]
+
+	return dungeonNames
+end
+
+local function Union ( a, b )
+    local result = {}
+    for k,v in pairs ( a ) do
+        result[k] = v
+    end
+    for k,v in pairs ( b ) do
+		result[k] = v
+    end
+    return result
+end
+
+GBB.VanillaDungeonLevels ={
+	["RFC"] = 	{13,18}, ["DM"] = 	{18,23}, ["WC"] = 	{15,25}, ["SFK"] = 	{22,30}, ["STK"] = 	{22,30}, ["BFD"] = 	{24,32},
+	["GNO"] = 	{29,38}, ["RFK"] = 	{30,40}, ["SMG"] = 	{28,38}, ["SML"] = 	{29,39}, ["SMA"] = 	{32,42}, ["SMC"] = 	{35,45},
+	["RFD"] = 	{40,50}, ["ULD"] = 	{42,52}, ["ZF"] = 	{44,54}, ["MAR"] = 	{46,55}, ["ST"] = 	{50,60}, ["BRD"] = 	{52,60},
+	["LBRS"] = 	{55,60}, ["DME"] = 	{58,60}, ["DMN"] = 	{58,60}, ["DMW"] = 	{58,60}, ["STR"] = 	{58,60}, ["SCH"] = 	{58,60},
+	["UBRS"] = 	{58,60}, ["MC"] = 	{60,60}, ["ZG"] = 	{60,60}, ["AQ20"]= 	{60,60}, ["BWL"] = {60,60},
+	["AQ40"] = 	{60,60}, ["NAX"] = 	{60,60},
+	["MISC"]=   {0,100}, ["TRAVEL"]={0,100}, ["INCUR"]={0,100},
+	["DEBUG"] = {0,100}, ["BAD"] =	{0,100}, ["TRADE"]=	{0,100}, ["SM2"] =  {28,42}, ["DM2"] =	{58,60}, ["DEADMINES"]={18,23},
+}
+
+GBB.PostTbcDungeonLevels = {
+	["RFC"] = 	{13,20}, ["DM"] = 	{16,24}, ["WC"] = 	{16,24}, ["SFK"] = 	{17,25}, ["STK"] = 	{21,29}, ["BFD"] = 	{20,28},
+	["GNO"] = 	{24,40}, ["RFK"] = 	{23,31}, ["SMG"] = 	{28,34}, ["SML"] = 	{30,38}, ["SMA"] = 	{32,42}, ["SMC"] = 	{35,44},
+	["RFD"] = 	{33,41}, ["ULD"] = 	{36,44}, ["ZF"] = 	{42,50}, ["MAR"] = 	{40,52}, ["ST"] = 	{45,54}, ["BRD"] = 	{48,60},
+	["LBRS"] = 	{54,60}, ["DME"] = 	{54,61}, ["DMN"] = 	{54,61}, ["DMW"] = 	{54,61}, ["STR"] = 	{56,61}, ["SCH"] = 	{56,61},
+	["UBRS"] = 	{53,61}, ["MC"] = 	{60,60}, ["ZG"] = 	{60,60}, ["AQ20"]= 	{60,60}, ["BWL"] = {60,60},
+	["AQ40"] = 	{60,60}, ["NAX"] = 	{60,60},
+	["MISC"] =  {0,100}, ["TRAVEL"]={0,100}, ["INCUR"]={0,100},
+	["DEBUG"] = {0,100}, ["BAD"] =	{0,100}, ["TRADE"]=	{0,100}, ["SM2"] =  {28,42}, ["DM2"] =	{58,60}, ["DEADMINES"]={16,24},
+}
+
+
+GBB.TbcDungeonLevels = {
+	["RAMPS"] =  {60,62}, 	["BF"] = 	 {61,63},     ["SP"] = 	 {62,64},    ["UB"] = 	 {63,65},     ["MT"] = 	 {64,66},     ["CRYPTS"] = {65,67},
+	["SETH"] =   {67,69},  	["OHB"] = 	 {66,68},     ["MECH"] =   {69,70},    ["BM"] =      {69,70},    ["MGT"] =	 {70,70},    ["SH"] =	 {70,70},
+	["BOT"] =    {70,70},    ["SL"] = 	 {70,70},    ["SV"] =     {70,70},   ["ARC"] = 	 {70,70},    ["KARA"] = 	 {70,70},    ["GL"] = 	 {70,70},
+	["MAG"] =    {70,70},    ["SSC"] =    {70,70}, 	["EYE"] =    {70,70},   ["ZA"] = 	 {70,70},    ["HYJAL"] =  {70,70}, 	["BT"] =     {70,70},
+	["SWP"] =    {70,70},
+}
+
+GBB.PvpLevels = {
+	["WSG"] = 	{10,70}, ["AB"] = 	{20,70}, ["AV"] = 	{51,70},   ["WG"] = {80,80}, ["SOTA"] = {80,80},  ["EOTS"] =   {15,70},   ["ARENA"] = {70,80},
+	["BLOOD"] = {0,100},
+}
+
+GBB.WotlkDungeonLevels = {
+	["UK"] =    {68,80},    ["NEX"] =    {69,80},    ["AZN"] =    {70,80},    ["ANK"] =    {71,80},    ["DTK"] =    {72,80},    ["VH"] =    {73,80},
+	["GD"] =    {74,80},    ["HOS"] =    {75,80},    ["HOL"] =    {76,80},    ["COS"] =    {78,80},    ["OCC"] =    {77,80},    ["UP"] =    {77,80},
+	["FOS"] =    {80,80},   ["POS"] =    {80,80},    ["HOR"] =    {80,80},    ["CHAMP"] =  {78,80},    ["OS"] =    {80,80},    ["VOA"] =    {80,80},
+	["EOE"] =    {80,80},   ["ULDAR"] =  {80,80},    ["TOTC"] =     {80,80},    ["RS"] =     {80,80},    ["ICC"] =    {80,80},    ["ONY"] =    {80,80},
+	["NAXX"] =   {80,80},   ["BREW"] = {65,70},      ["HOLLOW"] = {65,70},
+}
+
+GBB.WotlkDungeonNames = {
+	"UK", "NEX", "AZN", "ANK", "DTK", "VH", "GD", "HOS", "HOL", "COS",
+	"OCC", "UP", "FOS", "POS", "HOR", "CHAMP", "OS", "VOA", "EOE", "ULDAR",
+	"TOTC", "RS", "ICC", "ONY", "NAXX"
+}
+
+GBB.TbcDungeonNames = {
+	"RAMPS", "BF", "SH", "MAG", "SP", "UB", "SV", "SSC", "MT", "CRYPTS",
+	"SETH", "SL", "OHB", "BM", "MECH", "BOT", "ARC", "EYE", "MGT", "KARA",
+	"GL", "ZA", "HYJAL", "BT", "SWP",
+}
+
+GBB.VanillDungeonNames  = {
+	"RFC", "WC" , "DM" , "SFK", "STK", "BFD", "GNO",
+    "RFK", "SMG", "SML", "SMA", "SMC", "RFD", "ULD",
+    "ZF", "MAR", "ST" , "BRD", "LBRS", "DME", "DMN",
+    "DMW", "STR", "SCH", "UBRS", "MC", "ZG",
+    "AQ20", "BWL", "AQ40", "NAX",
+}
+
+
+GBB.PvpNames = {
+	"WSG", "AB", "AV", "EOTS", "WG", "SOTA", "ARENA",
+}
+
+GBB.PvpSodNames = {
+	"WSG", "AB", "AV", "BLOOD",
+}
+
+GBB.Misc = {"MISC", "TRADE", "TRAVEL", "INCUR"}
+
+GBB.DebugNames = {
+	"DEBUG", "BAD", "NIL",
+}
+
+GBB.Raids = {
+	"ONY", "MC", "ZG", "AQ20", "BWL", "AQ40", "NAX",
+	"KARA", "GL", "MAG", "SSC", "EYE", "ZA", "HYJAL",
+	"BT", "SWP", "ARENA", "WSG", "AV", "AB", "EOTS",
+	"WG", "SOTA", "BREW", "HOLLOW", "OS", "VOA", "EOE",
+	"ULDAR", "TOTC", "RS", "ICC", "NAXX",
+}
+
+GBB.Seasonal = {
+    ["BREW"] = { startDate = "09/20", endDate = "10/06"},
+	["HOLLOW"] = { startDate = "10/18", endDate = "11/01"}
+}
+
+GBB.SeasonalActiveEvents = {}
+GBB.Events = getSeasonalDungeons()
+GBB.PvpNames = getPvpByVersion()
+
+function GBB.GetRaids()
+	local arr = {}
+	for _, v in pairs (GBB.Raids) do
+		arr[v] = 1
+	end
+	return arr
+end
+
+-- Needed because Lua sucks, Blizzard switch to Python please
+-- Takes in a list of dungeon lists, it will then concatenate the lists into a single list
+-- it will put the dungeons in an order and give them a value incremental value that can be used for sorting later
+-- ie one list "Foo" which contains "Bar" and "FooBar" and a second list "BarFoo" which contains "BarBar"
+-- the output would be single list with "Bar" = 1, "FooBar" = 2, "BarFoo" = 3, "BarBar" = 4
+local function ConcatenateLists(Names)
+	local result = {}
+	local index = 1
+	for k, nameLists in pairs (Names) do
+		for _, v in pairs(nameLists) do
+			result[v] = index
+			index = index + 1
+		end
+	end
+	return result, index
+end
+
+local function GetSize(list)
+	local size = 0
+	for _, _ in pairs(list) do
+		size = size + 1
+	end
+	return size
+end
+
+function GBB.GetDungeonSort()
+	for eventName, eventData in pairs(GBB.Seasonal) do
+        if GBB.Tool.InDateRange(eventData.startDate, eventData.endDate) then
+			table.insert(GBB.WotlkDungeonNames, 1, eventName)
+		else
+			table.insert(GBB.DebugNames, 1, eventName)
+		end
+    end
+
+	local dungeonOrder = { GBB.VanillDungeonNames, GBB.TbcDungeonNames, GBB.WotlkDungeonNames, GBB.PvpNames, GBB.Misc, GBB.DebugNames}
+
+	-- Why does Lua not having a fucking size function
+	local vanillaDungeonSize = GetSize(GBB.VanillDungeonNames)
+
+	local tbcDungeonSize = GetSize(GBB.TbcDungeonNames)
+
+	local debugSize = GetSize(GBB.DebugNames)
+
+
+	local tmp_dsort, concatenatedSize = ConcatenateLists(dungeonOrder)
+	local dungeonSort = {}
+
+	GBB.TBCDUNGEONSTART = vanillaDungeonSize + 1
+	GBB.MAXDUNGEON = vanillaDungeonSize
+	GBB.TBCMAXDUNGEON = vanillaDungeonSize  + tbcDungeonSize
+	GBB.WOTLKDUNGEONSTART = GBB.TBCMAXDUNGEON + 1
+	GBB.WOTLKMAXDUNGEON = GetSize(GBB.WotlkDungeonNames) + GBB.TBCMAXDUNGEON
+	GBB.ENDINGDUNGEONSTART = GBB.WOTLKMAXDUNGEON + 1
+	GBB.ENDINGDUNGEONEND = concatenatedSize - debugSize - 1
+
+	for dungeon,nb in pairs(tmp_dsort) do
+		dungeonSort[nb]=dungeon
+		dungeonSort[dungeon]=nb
+	end
+
+	-- Need to do this because I don't know I am too lazy to debug the use of SM2, DM2, and DEADMINES
+	dungeonSort["SM2"] = 10.5
+	dungeonSort["DM2"] = 19.5
+	dungeonSort["DEADMINES"] = 99
+
+	return dungeonSort
+end
+
+local function DetermineVanillDungeonRange()
+
+	return GBB.PostTbcDungeonLevels
+
+end
+
+GBB.dungeonLevel = Union(Union(Union(DetermineVanillDungeonRange(), GBB.TbcDungeonLevels), GBB.WotlkDungeonLevels), GBB.PvpLevels)

--- a/LFGBulletinBoard/data/dungeons/wrath.lua
+++ b/LFGBulletinBoard/data/dungeons/wrath.lua
@@ -1,8 +1,7 @@
--- this file is here to keep old methods from breaking interim
--- it will be updated in the future
-
+-- this file is here to keep record of the old method. It is not used anymore.
 local TOCNAME,GBB=...
 
+if WOW_PROJECT_ID ~= WOW_PROJECT_WRATH_CLASSIC then return end
 local function getSeasonalDungeons()
     local events = {}
 

--- a/LFGBulletinBoard/data/tags.lua
+++ b/LFGBulletinBoard/data/tags.lua
@@ -1,0 +1,1000 @@
+local tocName, addon = ...
+---@type AddonEnum
+local AddonEnum = addon.Enum
+
+local isClassicEra = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local isCataclysm = WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC
+local isSoD = C_Seasons.GetActiveSeason() == Enum.SeasonID.SeasonOfDiscovery
+
+local debug = true
+local print = function(...)
+	if debug then
+		print('[' .. tocName .. ']', ...)
+	end
+end
+-----------------------------------------------------------------
+-- Tags
+-----------------------------------------------------------------
+-- note the string values are refered to as `tagString`s
+-- these strings are space delimited `tags`, which are split in a table usually called a `tagList`
+-- the individual tags in themselves cant contain spaces (otherwise it would get split into multiple tags)
+
+-- these tags are all defaults/Preset and can be modified ingame via the options.
+
+local suffixTagsLoc = {
+	enGB = "s group run runs", 
+	deDE = "gruppe",
+	ruRU = "группран фарм фарма фармить",
+	frFR = "groupe",
+	zhTW = "",
+	zhCN = "",
+}
+
+--- Tags usually prepended to an looking for group chat message, ie the "lfg" in "lfg wailing caverns"
+local searchTagsLoc = {
+	enGB = "group lfg lf lfm lftank lfheal lfhealer lfdps lfdd dd heal healer tank dps xdd xheal xhealer xtank druid hunter mage pala paladin priest rogue rouge shaman warlock warrior elite quest elitequest elitequests",
+
+	deDE = "gesucht suche suchen sucht such gruppe grp sfg sfm druide dudu jäger magier priester warri schurke rschami schamane hexer hexenmeister hm krieger heiler xheiler go run",
+
+	ruRU = "лфг ищет ищу нид нужны лфм лф2м ищем пати похилю лф танк хил нужен дд рдд мдд ршам рога вар прист армс пал",
+	frFR = "groupe cherche chasseur druide mage paladin pretre voleur chaman quete",
+
+	zhTW = "缺 來 找 徵 坦 補 DD 輸出 戰 聖 薩 獵 德 賊 法 牧 術",
+	zhCN = "= 缺 来 找 德 T N ND DZ FS SS SM",
+}
+
+-- tags for messages to ignore which may have matched a searchTag, 
+-- like spammed "lf layer" messages durring server launches.
+local badTagsLoc = {
+	enGB = "layer",
+	deDE = "fc",
+	ruRU = "гильдию гильдия слой",
+	frFR = "",
+	zhTW = "影布 回流",
+	zhCN = "影布 回流",
+}
+
+-- tags for identifying dungeon/raid difficulties
+local heroicTagsLoc = {
+	enGB = "h hc heroic",
+	deDE = "h hc heroic",
+	ruRU = "гер героик",
+	frFR = "h hc heroic hm hero heroique",
+	zhTW = "h 英雄",
+	zhCN = "h H 英雄",
+}
+
+-- Tags related to identifing dungeon or activity name from a message.
+
+local dungeonSecondTags = {
+	["DEADMINES"] = { "DM", "-DMW", "-DME", "-DMN" },
+	["SM2"] = { "SMG", "SML", "SMA", "SMC" },
+	["DM2"] = { "DMW", "DME", "DMN", "-DM" },
+}
+
+-- dungeonTagsLoc.enGB["DEADMINES"] = { "dm" }
+
+-- Remove any unused dungeon tags based on game version
+if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
+	local isSoD = C_Seasons.GetActiveSeason() == Enum.SeasonID.SeasonOfDiscovery
+	local exceptions = {
+		-- addon uses 2 different keys for nax in different locales
+		-- should be normalized to one key at some point
+		["NAXX"] = true,
+	}
+
+	-- Collect tags valid for vanilla
+	local validDungeons = {}
+	for _, key in ipairs(addon.VanillDungeonNames) do
+		validDungeons[key] = true
+	end
+	-- using PvPSodNames just coz it already only has the classic bgs
+	for _, key in ipairs(addon.PvpSodNames) do
+		if key == "BLOOD" then
+			-- only available in SoD
+			validDungeons[key] = isSoD
+		else
+			validDungeons[key] = true
+		end
+	end
+	for _, key in ipairs(addon.Misc) do
+		if key == "INCUR" then
+			-- only available in SoD
+			validDungeons[key] = isSoD
+		else
+			validDungeons[key] = true
+		end
+	end
+	-- iterate over all locales and `nil` out any entries for dungeons not valid for vanilla
+	for locale, dungeonTags in pairs(dungeonTagsLoc) do
+		for dungeonKey, _ in pairs(dungeonTags) do
+			if not (validDungeons[dungeonKey]
+					or exceptions[dungeonKey]
+					or dungeonSecondTags[dungeonKey])
+			then
+				dungeonTagsLoc[locale][dungeonKey] = nil
+			end
+		end
+	end
+end
+
+-- id like to offload these to a seperate system at some point.
+-- a more modular way of adding "categories" to the bulletin board
+-- the tags and the key and the display name for the category would all be defined in the same place
+local otherTags = {
+	TRADE = {
+	  enGB = "buy buying sell selling wts wtb hitem henchant htrade enchanter",
+	  deDE = "kaufe verkauf kauf verkaufe ah vk tg trinkgeld trinkgold vz schneider verzauberer verzaubere schliesskassetten schließkassetten kassetten schlossknacken schloßknacken alchimie",
+	  ruRU = "куплю продам втс втб чантера чант энчантера скрафчу сделаю чарю чары",
+	  frFR = "achete vends enchanteur vend",
+	  zhTW = "買 賣 售 收 代工 出售 附魔 COD",
+	  zhCN = "买 卖 收 代工 出售 附魔",
+	},
+	TRAVEL = {
+	  enGB = "sum summ summon summons summoning port portal travel",
+	  deDE = nil,
+	  ruRU = nil,
+	  frFR = nil,
+	  zhTW = nil,
+	  zhCN = nil,
+	},
+	BLOOD = {
+	  enGB = "blood bloodmoon bm",
+	  deDE = nil,
+	  ruRU = nil,
+	  frFR = nil,
+	  zhTW = nil,
+	  zhCN = nil,
+	},
+	INCUR = {
+	  enGB = "inc incur incursion incursions incurusions",
+	  deDE = nil,
+	  ruRU = nil,
+	  frFR = nil,
+	  zhTW = nil,
+	  zhCN = nil,
+	},
+}
+    
+local dungeonTags = {
+	AQ20 = { -- Ahn'Qiraj Ruins
+		enGB = "ruins aq20",
+		deDE = nil,
+		ruRU = "руины ра20 ак20 аку20",
+		frFR = nil,
+		zhTW = "RAQ AQ20 廢墟",
+		zhCN = "FX 废墟",
+	},
+	AQ40 = { -- Ahn'Qiraj Temple
+		enGB = "aq40",
+		deDE = nil,
+		ruRU = "ан40 ак40 аку40",
+		frFR = nil,
+		zhTW = "TAQ AQ40 安琪拉 安其拉",
+		zhCN = "TAQ 安其拉", 
+	},
+	ANK = { -- Ahn'kahet: The Old Kingdom
+		enGB = "ank old ako ok kingdom",
+		deDE = nil,
+		ruRU = "анкахет акнахет анк кахет",
+		frFR = "ank ahn",
+		zhTW = nil,
+		zhCN = "安卡赫特：古代王国 王国",
+	},
+	CRYPTS = { -- Auchenai Crypts
+		enGB = "crypts crypt auchenai ac acrypts acrypt",
+		deDE = "krypta auchenaikrypta auchen",
+		ruRU = "аукенайские аг аукенские аукинайские аук аукен",
+		frFR = "crypte cryptes crypts crypt auchenaï auchenai",
+		zhTW = "地穴",
+		zhCN = "地穴",
+	},
+	AZN = { -- Azjol-Nerub
+		enGB = "azn an nerub",
+		deDE = nil,
+		ruRU = "азжол ажзол азжолнеруб ажзолнеруб",
+		frFR = "azjol nerub az azol azjob",
+		zhTW = nil,
+		zhCN = "艾卓",
+	},
+	NULL = { -- Baradin Hold
+
+	},
+	BT = { -- Black Temple
+		enGB = "bt",
+		deDE = "tempel bt black blacktempel blacktemple temple",
+		ruRU = "бт иллидан илидан",
+		frFR = nil,
+		zhTW = "黑暗神廟 黑廟",
+		zhCN = "黑暗神庙 黑庙", 
+	},
+	BFD = { -- Blackfathom Deeps
+		enGB = "bfd blackfathom fathom",
+		deDE = "bft blackfathomtiefen tiefschwarze grotte tsg",
+		ruRU = "нп непроглядная пучина пучину",
+		frFR = "brassenoire",
+		zhTW = "黑暗深淵",
+		zhCN = "黑暗深渊",
+	},
+	NULL = { -- Blackrock Caverns
+
+	},
+
+	-- all these can get redirected to the pre-cata "BRD" for the time being.
+	-- these did not exists colloquially as wings pre-cata,
+	NULL = { -- Blackrock Depths - Detention Block
+
+	},
+	NULL = { -- Blackrock Depths - Upper City
+
+	},
+
+	NULL = { -- Blackwing Descent
+
+	},
+	BWL = { -- Blackwing Lair
+		enGB = "blackwing bwl",
+		deDE = nil,
+		ruRU = "логово крыла тьмы лкт",
+		frFR = nil,
+		zhTW = "BWL 黑翼",
+		zhCN = "BWL 黑翼",
+	},
+	BF = { -- Blood Furnace
+		enGB = "furnace furn bf",
+		deDE = "bk kessel blutkessel",
+		ruRU = "крови кк",
+		frFR = "fournaise",
+		zhTW = "血熔爐 熔爐 融爐 血熔盧 熔盧 融盧",
+		zhCN = "熔炉",
+	},
+	BREW = { -- Coren Direbrew (Brewfest)
+		enGB = "brewfest brew coren dire direbrew beerfest",
+		deDE = nil,
+		ruRU = "хмельной фестиваль корен худовар",
+		frFR = nil,
+		zhTW = nil,
+		zhCN = nil,
+	},
+	DM = { -- Deadmines
+		enGB = "deadmines vc vancleef dead mines mine",
+		deDE = "todesminen todesmine tm",
+		ruRU = "мк мертвые копи ванклиф",
+		frFR = "mm mortemines mine mortemine",
+		zhTW = "死亡礦坑 死況 死礦",
+		zhCN = "死亡矿坑 死矿",
+	},
+
+	-- When changing tag strings for diremaul dungeons make sure to consider
+	-- other versions of the game since the wings might be referred to differently. 
+	DMW = { -- Dire Maul - Capital Gardens (DMW pre-cata)
+		enGB = "dmw dmwest west",
+		deDE = "dbw dbwest",
+		ruRU = "дмв запад дмзапад",
+		frFR = "ouest",
+		zhTW = "厄西 惡西 噩西",
+		zhCN = "厄运西",
+	},
+	DMN = { -- Dire Maul - Gordok Commons (DMN pre-cata)
+		enGB = "dmn dmnorth north tribute",
+		deDE = "tribut dbn nord dbnord",
+		ruRU = "дмн дмсевер север трибут трибьют",
+		frFR = "tribut nord",
+		zhTW = "厄北 惡北 噩北 完美厄運 完美惡運 完美噩運",
+		zhCN = "厄运北 完美厄运",
+	},
+	DME = { -- Dire Maul - Warpwood Quarter (DME pre-cata)
+		enGB = "dme dmeast east puzilin jumprun",
+		deDE = "ost dbo dbost",
+		ruRU = "восток вдм дмвосток джампран",
+		frFR = "htest",
+		zhTW = "厄東 惡東 噩東",
+		zhCN = "厄运东",
+	},
+
+	NULL = { -- Dragon Soul
+
+	},
+	DTK = { -- Drak'Tharon Keep
+		enGB = "dtk drak draktharon drak'tharon",
+		deDE = nil,
+		ruRU = "драк'тарон драктарон",
+		frFR = "dtk drak draktharon drak'tharon drak",
+		zhTW = nil,
+		zhCN = "达克萨隆要塞 达克萨隆",
+	},
+	NULL = { -- End Time
+
+	},
+	NULL = { -- Fall of Deathwing
+
+	},
+	NULL = { -- Firelands
+
+	},
+	GNO = { -- Gnomeregan
+		enGB = "gnomer gno gnomeregan gnomeragan gnome gnomregan gnomragan gnom gnomergan",
+		deDE = nil,
+		ruRU = "гномреган гномер гномрег гномериган гномерган",
+		frFR = nil,
+		zhTW = "諾姆瑞根",
+		zhCN = "诺莫瑞根",
+	},
+	NULL = { -- Grim Batol
+
+	},
+	GL = { -- Gruul's Lair
+		enGB = "gl gruul gruuls gruul's",
+		deDE = "grull grul gruul",
+		ruRU = "грул груула",
+		frFR = nil,
+		zhTW = "戈魯 魯爾 戈乳 哥魯 哥乳",
+		zhCN = "格鲁尔",
+	},
+	GD = { -- Gundrak
+		enGB = "gd gundrak",
+		deDE = nil,
+		ruRU = "гундрак гуднрак гун драк",
+		frFR = "gd gundrak",
+		zhTW = nil,
+		zhCN = "古达克",
+	},
+	HOL = { -- Halls of Lightning
+		enGB = "hol lightning",
+		deDE = nil,
+		ruRU = "молний чм",
+		frFR = "sdf",
+		zhTW = nil,
+		zhCN = "闪电大厅",
+	},
+	NULL = { -- Halls of Origination
+
+	},
+	HOR = { -- Halls of Reflection
+		enGB = "hor reflection",
+		deDE = nil,
+		ruRU = "залы отражений кяз",
+		frFR = nil,
+		zhTW = nil,
+		zhCN = "映像大厅",
+	},
+	HOS = { -- Halls of Stone
+		enGB = "hos stone",
+		deDE = nil,
+		ruRU = "камня чк",
+		frFR = "sdp",
+		zhTW = nil,
+		zhCN = "岩石大厅",
+	},
+	RAMPS = { -- Hellfire Ramparts
+		enGB = "ramparts rampart ramp ramps",
+		deDE = "bm bollwerk höllenfeuerbollwerk bw",
+		ruRU = "бастионы адского пламени цап бастион бап рампы",
+		frFR = "remparts rempart renpart ranpart renparts rampart ramparts",
+		zhTW = "堡壘 壁壘 火堡 火壘 火堡壘 火壁壘",
+		zhCN = "碉堡",
+	},
+	NULL = { -- Hour of Twilight
+
+	},
+	HYJAL = { -- Hyjal Past
+		enGB = "hyjal hs hyj",
+		deDE = "hdz3 mount hyjal mounthyjal ",
+		ruRU = "хиджал",
+		frFR = nil,
+		zhTW = "海珊 海山 海加爾",
+		zhCN = "海山 海加尔",
+	},
+	ICC = { -- Icecrown Citadel
+		enGB = "icc icecrown citadel",
+		deDE = nil,
+		ruRU = "цлк",
+		frFR = "icc icecrown citadel icc10 icc25",
+		zhTW = nil,
+		zhCN = "冰冠碉堡",
+	},
+
+	KARA = { -- Karazhan
+		enGB = "kara kz karazhan",
+		deDE = "kara karazahn",
+		ruRU = "каражан кара караджан кару",
+		frFR = nil,
+		zhTW = "卡拉 卡啦",
+		zhCN = "KLZ 卡拉赞",
+	},
+	NULL = { -- Lost City of the Tol'vir
+
+	},
+	LBRS = { -- Lower Blackrock Spire
+		enGB = "lower lbrs lrbs",
+		deDE = nil,
+		ruRU = "лбрс нвчг нпчг нижний низ",
+		frFR = nil,
+		zhTW = "黑下 黑石塔下",
+		zhCN = "黑下 黑石塔下",
+	},
+	MGT = { -- Magisters' Terrace
+		enGB = "mgt mrt terrace magisters magister",
+		deDE = "tdm terasse",
+		ruRU = "тераса терраса магистров тм",
+		frFR = nil,
+		zhTW = "博學",
+		zhCN = "博学",
+	},
+	MAG = { -- Magtheridon's Lair
+		enGB = "mag magtheridon magtheridon's magth",
+		deDE = "maggi magi magtheridons magtheridon",
+		ruRU = "мага магтеридон",
+		frFR = nil,
+		zhTW = "馬肥 瑪色 馬瑟 瑪瑟",
+		zhCN = "马肥 玛瑟里顿",
+	},
+	MT = { -- Mana-Tombs
+		enGB = "manatombs mana mt tomb tombs",
+		deDE = "mg gruft managruft manatomb tomb mana",
+		ruRU = "маны гм манатомбс манатомбы томбы мана томбс манатобс манатомб манатомс ману",
+		frFR = "tombe mana tm manatomb",
+		zhTW = "法力 墓地 法墓",
+		zhCN = "法力 陵墓 法墓",
+	},
+
+	-- all these can get redirected the "MARA" catchall for the time being.
+	-- these did not exists as wings pre-cata, just entrances (princess, orange, purple)
+	-- Maraudon - Earth Song Falls
+	NULL = 273,	
+	-- Maraudon - Foulspore Cavern
+	NULL = 26,  
+	-- Maraudon - The Wicked Grotto
+	NULL = 272,	
+	
+	MC = { -- Molten Core
+		enGB = "molten core mc",
+		deDE = "kern",
+		ruRU = "недра",
+		frFR = nil,
+		zhTW = "MC 熔火 螺絲",
+		zhCN = "MC 熔火",
+	},    
+	NAXX = { -- Naxxramas
+		enGB = "naxxramas nax naxx nax10 naxx10 nax25 naxx25",
+		deDE = nil,
+		ruRU = "наксрамас накс наксарамас",
+		frFR = "naxxramas nax naxx nax10 naxx10 nax25 naxx25",
+		zhTW = "naxx 老克 納克",
+		zhCN = "naxx 纳克萨玛斯",
+	},	
+	ONY = { -- Onyxia's Lair
+		enGB = "onyxia ony",
+		deDE = nil,
+		ruRU = "ониксия оня ониксию",
+		frFR = nil,
+		zhTW = "黑妹 龍妹 奧妮 ONYX",
+		zhCN = "黑龙 奧妮克希亞",
+	},  
+	BM = { --- Opening of the Dark Portal (aka the Black Morass)
+		enGB = "morass bm black",
+		deDE = "hdz2 morast",
+		ruRU = "черные топи",
+		frFR = "gt2",
+		zhTW = "18波 黑色沼澤 黑沼 沼澤",
+		zhCN = "18波 黑色沼澤 黑沼 沼澤",
+	},
+	POS = { -- Pit of Saron
+		enGB = "pos pit saron",
+		deDE = nil,
+		ruRU = "яма яму сарона кяз",
+		frFR = nil,
+		zhTW = nil,
+		zhCN = "萨隆深渊",
+	},
+	RFC = { -- Ragefire Chasm
+		enGB = "rfc ragefire chasm",
+		deDE = "rfa ragefireabgrund flammenschlund flamenschlund rf rfg",
+		ruRU = "оп огненная пропасть",
+		frFR = "rfc ragefeu",
+		zhTW = "怒焰裂谷 怒驗 怒焰",
+		zhCN = "怒焰峡谷 怒焰",
+	},    
+	RFD = { -- Razorfen Downs
+		enGB = "rfd downs",
+		deDE = "hügel huegel",
+		ruRU = "ки курганы",
+		frFR = "souille souilles",
+		zhTW = "剃刀高地",
+		zhCN = "剃刀高地",
+	},   
+	RFK = { -- Razorfen Kraul
+		enGB = "rfk kraul",
+		deDE = "kral krall karl",
+		ruRU = "ли лабиринты",
+		frFR = "kraal",
+		zhTW = "剃刀沼澤",
+		zhCN = "剃刀沼泽",
+	},   
+	RS = { -- Ruby Sanctum
+		enGB = "rs ruby sanctum hal hal10 hal25",
+		deDE = nil,
+		ruRU = "рубиновое святилище рс",
+		frFR = nil,
+		zhTW = nil,
+		zhCN = "红玉圣殿",
+	},	
+	SMA = { -- Scarlet Monastery - Armory
+		enGB = "smarm sma arm armory herod armoury arms",
+		deDE = "wk waffenkammer arsenal",
+		ruRU = "оружейная армори арм оружейка",
+		frFR = "armu armurerie",
+		zhTW = "軍械",
+		zhCN = "武器库",
+	},	
+	SMC = { -- Scarlet Monastery - Cathedral
+		enGB = "smcath smc cath cathedral",
+		deDE = "kathe kathedrale kath katha kahte",
+		ruRU = "собор",
+		frFR = "cathé cathe",
+		zhTW = "教堂",
+		zhCN = "教堂",
+	},	
+	SMG = { -- Scarlet Monastery - Graveyard
+		enGB = "smgy smg gy graveyard",
+		deDE = "friedhof hof fh freidhof",
+		ruRU = "кладбон кладбище",
+		frFR = "cimetière cimetiere cim",
+		zhTW = "血色墓地",
+		zhCN = "血色墓地",
+	},   
+	SML = { -- Scarlet Monastery - Library
+		enGB = "smlib sml lib library",
+		deDE = "bibli bibi bibliothek bib bücherei bibo biblio biblo bibl",
+		ruRU = "библиотека библиотеку библу библа",
+		frFR = "bibli bibliothèque bibliotheque librairie",
+		zhTW = "血色圖書館",
+		zhCN = "血色图书馆",
+	},	
+	SCH = { -- Scholomance
+		enGB = "scholomance scholo sholo sholomance",
+		deDE = nil,
+		ruRU = "шоло некроситет некр",
+		frFR = nil,
+		zhTW = "通靈",
+		zhCN = "通灵",
+	},    
+	SSC = { -- Serpentshrine Cavern
+		enGB = "ssc serpentshrine serpentshine",
+		deDE = "ssc vashi schlangenschrein",
+		ruRU = "резервуар Кривого Клыка змеиное святилище зс",
+		frFR = nil,
+		zhTW = "毒蛇",
+		zhCN = "毒蛇",
+	},	
+	SETH = { -- Sethekk Halls
+		enGB = "sethekk seth sethek",
+		deDE = "sh sethekhallen seth sethek",
+		ruRU = "сетеккские залы сз сетеки сеттек сетекские сетеков сетеккскиезалы сеттекские",
+		frFR = "sethekk seth sethek setthek settek",
+		zhTW = "鳥廳 塞斯克 塞司克 賽司克 賽斯克 鳥聽 烏鴉",
+		zhCN = "鸟厅",
+	},	
+	SL = { -- Shadow Labyrinth
+		enGB = "sl slab labyrinth lab",
+		deDE = "sl schlabby schattenlab shadow schattenlaby shadowlab",
+		ruRU = "темный тёмный  лаберинт лабиринт шл лаба",
+		frFR = "labyrinth lab laby shadowlab",
+		zhTW = "迷宮 暗影 暗宮",
+		zhCN = "迷宮",
+	},	
+	SFK = { -- Shadowfang Keep
+		enGB = "sfk shadowfang",
+		deDE = "burg bsf schattenfang",
+		ruRU = "ктк темного клыка",
+		frFR = "ombrecroc",
+		zhTW = "影牙城堡 影牙",
+		zhCN = "影牙城堡 影牙",
+	},    
+	SH = { -- Shattered Halls
+		enGB = "sh shattered shatered shaterred",
+		deDE = "zh zerschmetterte hallen",
+		ruRU = "разрушенные рз разрушенных разрушеные",
+		frFR = "salles salle brisées brisees brise brisés brisé sb brisée halls",
+		zhTW = "破碎",
+		zhCN = "破碎",
+	},	
+	SP = { -- Slave Pens
+		enGB = "slavepens pens sp",
+		deDE = "sp sklaven sklavenunterkünfte",
+		ruRU = "узилище узилише улилище узилища узилеще узлще",
+		frFR = "enclos enclo",
+		zhTW = "奴隸 監獄 奴監",
+		zhCN = "围栏",
+	},	
+	STK = { -- Stormwind Stockade
+		enGB = "stk stock stockade stockades",
+		deDE = "verlies verließ verliess",
+		ruRU = "тюрьма тюрьму тюрягу",
+		frFR = "prison",
+		zhTW = nil,
+		zhCN = nil,
+	},
+
+	-- all these can get redirected to the pre-cata "STRAT" for the time being.
+	NULL = { -- Stratholme - Main Gate
+
+	},  
+	NULL = { -- Stratholme - Service Entrance
+
+	},
+
+	ST = { -- Sunken Temple
+		enGB = "st sunken atal temple",
+		deDE = "tempel",
+		ruRU = "зх затанувший храм санкен сункен темпл",
+		frFR = "st sunken englouti atal",
+		zhTW = "神廟 阿塔哈卡",
+		zhCN = "神庙",
+	},    
+	EYE = { -- Tempest Keep (The Eye)
+		enGB = "eye tk",
+		deDE = "auge tk fds",
+		ruRU = "бурь фениксом",
+		frFR = nil,
+		zhTW = "風暴 要塞 鳳凰",
+		zhCN = "风暴 要塞",
+	},	
+	ARC = { -- The Arcatraz
+		enGB = "arc arcatraz alcatraz",
+		deDE = "arca arka arkatraz arcatraz",
+		ruRU = "аркатрац кба алькатрац аркатрас алькатрас алькатраз арка аркатраз",
+		frFR = "arca",
+		zhTW = "亞克",
+		zhCN = "禁魔监狱",
+	},	
+	NULL = { -- The Bastion of Twilight
+
+	},	
+	BOT = { -- The Botanica
+		enGB = "botanica bot",
+		deDE = "bota botanika botanica",
+		ruRU = "ботаника кбб ботанику бот боту",
+		frFR = "botanica bota",
+		zhTW = "波塔 波卡",
+		zhCN = "生态船",
+	},	
+	NULL = { -- The Crown Chemical Co. (Love is in the Air)
+
+	},	
+	COS = { -- The Culling of Stratholme
+		enGB = "culling cos",
+		deDE = nil,
+		ruRU = "очищение страт стратхольм",
+		frFR = "gt4",
+		zhTW = nil,
+		zhCN = "净化斯坦索姆 stsm STSM",
+	},	
+	OHB = { -- The Escape From Durnholde (Old Hillsbrad Foothills)
+		enGB = "ohb oh ohf durnholde hillsbrad escape",
+		deDE = "hdz1 hillsbrad",
+		ruRU = "cтарые предгорья хилсбрада спх старый хилсбрад хилсбард побег дарнхольд",
+		frFR = "gt1",
+		zhTW = "索爾 丘陵",
+		zhCN = "索尔",
+	},	
+	EOE = { -- The Eye of Eternity
+		enGB = "eoe maly eternity",
+		deDE = nil,
+		ruRU = "око вечности малигос малигоса",
+		frFR = "maly malygos may",
+		zhTW = nil,
+		zhCN = "永恒之眼 蓝龙",
+	},	
+	FOS = { -- The Forge of Souls
+		enGB = "fos forge soul",
+		deDE = nil,
+		ruRU = "кузня душ кузню кяз",
+		frFR = nil,
+		zhTW = nil,
+		zhCN = "灵魂洪炉",
+	},	
+	NULL = { -- The Frost Lord Ahune (Midsummer)
+	},	
+	HOLLOW = { -- The Headless Horseman
+		enGB = "headless horseman hollow",
+		deDE = nil,
+		ruRU = "всадник",
+		frFR = nil,
+		zhTW = nil,
+		zhCN = nil,
+	},	
+	MECH = { -- The Mechanar
+		enGB = "mech mechanar",
+		deDE = "mecha mechanar mech",
+		ruRU = "механар кбм механар мех меха меху",
+		frFR = "méca mech mechanar méchanar",
+		zhTW = "麥克",
+		zhCN = "能源舰",
+	},	
+	NEX = { -- The Nexus
+		enGB = "nexus nex",
+		deDE = nil,
+		ruRU = "нексус",
+		frFR = "nexus nex",
+		zhTW = nil,
+		zhCN = "魔枢",
+	},	
+	OS = { -- The Obsidian Sanctum
+		enGB = "sarth obsidian sanctum",
+		deDE = nil,
+		ruRU = "ос обсидиановое святилище сарт сартарион сартариона",
+		frFR = "sarth sart sanctum sartha sartha10 sartha25 sarta10 sarta25",
+		zhTW = nil,
+		zhCN = "黑曜石圣殿 红龙",
+	},	
+	OCC = { -- The Oculus
+		enGB = "occ oculus",
+		deDE = nil,
+		ruRU = "окулус",
+		frFR = "occulus oculus",
+		zhTW = nil,
+		zhCN = "魔环",
+	},	
+	NULL = { -- The Siege of Wyrmrest Temple
+
+	},	
+	SV = { -- The Steamvault
+		enGB = "sv steamvault steamvaults steam vault valts",
+		deDE = "dk dampfkammer",
+		ruRU = "резервуар паровое паравое паровые пп парового",
+		frFR = "steam vault réservoir reservoir caveau caveaux",
+		zhTW = "蒸氣 蒸汽",
+		zhCN = "蒸汽 地窖",
+	},	
+	NULL = { -- The Stonecore
+
+	},	
+	SWP = { -- The Sunwell
+		enGB = "swp sunwell plateau plataeu sunwel",
+		deDE = nil,
+		ruRU = "плато свп санвел санвэл",
+		frFR = nil,
+		zhTW = "太陽",
+		zhCN = "太阳井",
+	},	
+	NULL = { -- The Vortex Pinnacle
+
+	},	
+	NULL = { -- Throne of the Four Winds
+
+	},	
+	NULL = { -- Throne of the Tides
+
+	},	
+	CHAMP = { -- Trial of the Champion
+		enGB = "champ toc champion",
+		deDE = nil,
+		ruRU = "чемпиона ич",
+		frFR = "champ toc champion",
+		zhTW = nil,
+		zhCN = "冠军的试炼",
+	},
+	TOTC = { -- Trial of the Crusader/Trial of the Grand Crusader
+		enGB = "tc totc totc10 totc25 toc10 toc25 togc",
+		deDE = nil,
+		ruRU = "крестоносца ик",
+		frFR = "tc totc totc10 totc25 toc10 toc25 togc",
+		zhTW = nil,
+		zhCN = "十字军的试炼",
+	},
+	ULD = { -- Uldaman
+		enGB = "uld ulda uldaman ulduman uldman uldama udaman",
+		deDE = "uldamann",
+		ruRU = "ульда ульдаман ульдман улдаман ульдуман",
+		frFR = nil,
+		zhTW = "奧達曼",
+		zhCN = "奥达曼",
+	},
+	ULDAR = { -- Ulduar
+		enGB = "uld ulduar",
+		deDE = nil,
+		ruRU = "ульдуар ульд ульда йог",
+		frFR = "uldu uld uldu10 uldu25 ulduar ulduar10 ulduar25",
+		zhTW = nil,
+		zhCN = "奥杜尔",
+	},
+	UB = { -- Underbog
+		enGB = "underbog ub",
+		deDE = "ts sumpf tiefensumpf tiefen",
+		ruRU = "нижетопь нт нежитопь нижнетопь",
+		frFR = "bt basse tourbière tourbiere",
+		zhTW = "深幽 泥沼",
+		zhCN = "幽暗 泥沼",
+	},
+	UBRS = { -- Upper Blackrock Spire
+		enGB = "upper ubrs urbs rend",
+		deDE = nil,
+		ruRU = "убрс ввчг вчвчг впчг вчпчг верх верхний",
+		frFR = nil,
+		zhTW = "黑上 黑石塔上",
+		zhCN = "黑上 黑石塔上",
+	},
+	UK = { -- Utgarde Keep
+		enGB = "uk utk utgarde",
+		deDE = nil,
+		ruRU = "крепость",
+		frFR = nil,
+		zhTW = nil,
+		zhCN = "乌特加德城堡 乌堡",
+	},
+	UP = { -- Utgarde Pinnacle
+		enGB = "up pinnacle",
+		deDE = nil,
+		ruRU = "вершина верх",
+		frFR = "cime",
+		zhTW = nil,
+		zhCN = "乌特加德之巅 乌巅",
+	},
+	VOA = { -- Vault of Archavon
+		enGB = "voa vault archavon",
+		deDE = nil,
+		ruRU = "склеп аркавона аркавон",
+		frFR = "archa acha archavon",
+		zhTW = nil,
+		zhCN = "阿尔卡冯的宝库 宝库 色球",
+	},
+	VH = { -- Violet Hold
+		enGB = "vh violet hold",
+		deDE = nil,
+		ruRU = "аметистовая амк",
+		frFR = "fp fort",
+		zhTW = nil,
+		zhCN = "紫罗兰监狱 监狱",
+	},
+	WC = { -- Wailing Caverns
+		enGB = "wc wailing caverns",
+		deDE = "hdw wehklagens",
+		ruRU = "пс стенаний пещеры",
+		frFR = "lams lam lamentations",
+		zhTW = "哀嚎洞穴 哀號 哀嚎",
+		zhCN = "哀嚎洞穴 哀嚎",
+	},
+	NULL = { -- Well of Eternity
+
+	},
+	ZA = { -- Zul'Aman
+		enGB = "za zulaman zul-aman zaman aman zul'aman",
+		deDE = "za zulaman aman zul",
+		ruRU = "зул'аман зуламан ЗА",
+		frFR = nil,
+		zhTW = "ZA 阿曼",
+		zhCN = "ZA 祖阿曼",
+	},
+	ZF = { -- Zul'Farrak
+		enGB = "zf zul farrak zul'farrak zulfarrak zulfarak zul´farrak zul`farrak zulfa zulf",
+		deDE = nil,
+		ruRU = "зф фарак фаррак зул'фаррак зулфарак зулфаррак зульфарак",
+		frFR = nil,
+		zhTW = "ZF 組爾法 祖爾法",
+		zhCN = "ZLF 祖尔法拉克",
+	},
+	ZG = { -- Zul'Gurub 
+		enGB = "zg gurub zul'gurub zulgurub zul´gurub zul`gurub zulg",
+		deDE = nil,
+		ruRU = "зг гуруб зул'гуруб  зулгуруб  зул?гуруб зул`гуруб зул'гуруба",
+		frFR = nil,
+		zhTW = "ZG 祖爾格 組爾格 龍虎",
+		zhCN = "ZG 祖格",
+	},
+
+	-- Misc. Dungeons
+	SM2 = { -- Base Scarlet Monastery catch-all for all wings
+		enGB = "sm scarlet monastery mona",
+		deDE = "kloster",
+		ruRU = "мао монастырь",
+		frFR = nil,
+		zhTW = "血色",
+		zhCN = "血色",
+	},
+	DM2 = { -- Base Dire Maul catch-all for all wings
+		enGB = "dire maul diremaul",
+		deDE = "düsterbruch duesterbruch db",
+		ruRU = "дм забытый город",
+		frFR = "ht hache-tripes hachetripes hache tripe tripes",
+		zhTW = "厄運 惡運 噩運",
+		zhCN = "厄运",
+	},
+	BRD = { -- Blackrock Depths (Pre Cata, no wings)
+		enGB = "brd emperor emp arenarun angerforge blackrockdepth",
+		deDE = "blackrocktiefen blackrock brt imperator imp",
+		ruRU = "брд гчг глубины генерал ран глубины черной горы",
+		frFR = "brd profondeur profondeurs",
+		zhTW = "黑深 深淵",
+		zhCN = "黑石深渊",
+	},	
+	STR = { -- Stratholme (Pre Cata, no wings)
+		enGB = "stratlive live living stratUD undead ud baron stratholme stath stratholm strah strath strat starth",
+		deDE = "lebend untot",
+		ruRU = "ст",
+		frFR = nil,
+		zhTW = "斯坦",
+		zhCN = "stsm 斯坦索姆",
+	},
+	MAR = { -- Maraudon (Pre Cata, no wings)
+		enGB = "mar mara maraudon mauradon mauro maurodon princessrun maraudin maura marau mauraudon",
+		deDE = "prinzessinnenrun prinzessinenrun prinzessinrun prinzessrun",
+		ruRU = "мар мара марадон мараудон мару мародон мароудон мродон мородон",
+		frFR = nil,
+		zhTW = "馬拉 瑪拉",
+		zhCN = "玛拉顿",
+	},
+
+	-- Cata pre-patch dungeon bosses
+	NULL = { -- Crown Princess Theradras
+	},
+	NULL = { -- Grand Ambassador Flamelash
+	},
+	NULL = { -- Kai'ju Gahz'rilla
+	},
+	NULL = { -- Prince Sarsarun
+	},
+
+	-- PvP
+	RBG = { -- 10v10 Rated Battleground
+	},
+	ARENA = { -- 2v2 3v3 5v5 Arena
+		enGB = "2s 3s 5s 3v3 5v5 2v2 2vs2 3vs3 5vs5",
+		deDE = "2s 3s 5s 3v3 5v5 2v2 2vs2 3vs3 5vs5",
+		ruRU = "2s 3s 5s 2с 3с 5с 2x2 3x3 5x5 2х2 3х3 5х5 2на2 3на3 5на5 кап",
+		frFR = "2s 3s 5s 3v3 5v5 2v2 2vs2 3vs3 5vs5",
+		zhTW = "競技 22 33 3v3 5v5 2v2 2vs2 3vs3 5vs5",
+		zhCN = "竞技 22 33 3v3 5v5 2v2 2vs2 3vs3 5vs5",
+    },
+	AV = { -- Alterac Valley
+		enGB = "av valley",
+		deDE = nil,
+		ruRU = "ад альтеракская долина ",
+		frFR = "alterac",
+		zhTW = "奧山 奧特蘭",
+		zhCN = "奧山 奥特兰",
+	},	
+	AB = { -- Arathi Basin
+		enGB = "basin ab",
+		deDE = nil,
+		ruRU = "низина арати",
+		frFR = "arathi",
+		zhTW = "阿拉溪 阿拉希 阿拉西",
+		zhCN = "阿拉希",
+	},	
+	EOTS = { -- Eye of the Storm
+		enGB = "storm eots",
+		deDE = "ads",
+		ruRU = "бури",
+		frFR = nil,
+		zhTW = "暴風眼 暴風之眼",
+		zhCN = "风暴之眼",
+	},	
+	NULL = { -- Isle of Conquest
+
+	},	
+	SOTA = { -- Strand of the Ancients
+		enGB = "sota strand ancient",
+		deDE = nil,
+		ruRU = "берег древних",
+		frFR = nil,
+		zhTW = nil,
+		zhCN = nil,
+	},	
+	WSG = { -- Warsong Gulch
+		enGB = "wsg warsong ws",
+		deDE = "warsongschlucht schlucht",
+		ruRU = "упв ущелье песни войны варсонг всг",
+		frFR = nil,
+		zhTW = "戰哥 戰歌",
+		zhCN = "战歌",
+	},
+	WG = { -- Wintergrasp
+		enGB = "wg wintergrasp",
+		deDE = nil,
+		ruRU = "оло озеро",
+		frFR = nil,
+		zhTW = nil,
+		zhCN = nil,
+	}
+}

--- a/LFGBulletinBoard/utils/debug.lua
+++ b/LFGBulletinBoard/utils/debug.lua
@@ -1,0 +1,81 @@
+local tocName, shared = ...
+local profilingCache = {}
+local debugHeader = KYRIAN_BLUE_COLOR
+    :WrapTextInColorCode('[' .. tocName .. ']:');
+local function print(...)
+    return _G.print(debugHeader, ...)
+end
+---@param key string
+local function benchMarkStart(key)
+    local _debugstart = debugprofilestop()
+    local cache = profilingCache[key] or {};
+    cache.start = _debugstart
+    profilingCache[key] = cache
+end
+benchMarkStart("Full Addon Load")
+---@param key string
+local function benchMarkPrint(key)
+    local cache = profilingCache[key];
+    if not cache then
+        print("No cache for key: ", key)
+        return
+    end
+    print(("%s took: %.4fms | avg: %.4fms | samples: %i"):format(key, cache.elapsed, cache.avg, cache.samples))
+end
+
+---@param key string
+---@param abort boolean # if true, the cache entry will be removed
+---@param print boolean # if true, profiling data will be printed
+local function benchMarkStop(key, abort, print)
+    local _debugend = debugprofilestop()
+    local cache = profilingCache[key];
+    if not cache then
+        print("No cache for key: ", key)
+        return
+    end
+    if abort then
+        return
+    end
+    cache.stop = _debugend
+    cache.elapsed = cache.stop - cache.start
+    cache.samples = (cache.samples or 0) + 1
+    cache.avg = cache.avg and (cache.avg + cache.elapsed) / 2 or cache.elapsed
+    profilingCache[key] = cache
+    if print then
+        benchMarkPrint(key)
+    end
+end
+
+local function profilefunc(funcOrTable, keyOrMember)
+    local result
+    if type(funcOrTable) == "function" then
+        assert(type(keyOrMember) == "string", "arg2; profiling cache key must be a string")
+        benchMarkStart(keyOrMember)
+        result = { pcall(funcOrTable) }
+    else
+        assert(type(funcOrTable) == "table",
+            "arg1 must be either a function reference or a table to query for a function")
+        assert(type(keyOrMember) == "string", "arg2; table member functions key must be a string")
+        local func = funcOrTable[keyOrMember]
+        assert(type(func) == "function", "arg2; table member must be a function")
+        benchMarkStart(keyOrMember)
+        result = { pcall(func, funcOrTable) }
+    end
+    local isOk = result[1]
+    benchMarkStop(keyOrMember, not isOk)
+    if isOk then
+        benchMarkPrint(keyOrMember)
+    end
+    if isOk then -- all ok
+        return unpack(result, 2)
+    else         -- error
+        print("Profiling failed: Error in function: ", result[2])
+        error(result[2])
+    end
+end
+
+shared.benchMarkStart = benchMarkStart
+shared.benchMarkStop = benchMarkStop
+shared.benchMarkPrint = benchMarkPrint
+shared.profilefunc = profilefunc
+shared.print = print


### PR DESCRIPTION
@Vysci as you mentioned that post WotLK you plan on making this a classic era only addon, ive started some work at trying to go through and seeing what is/isnt necessary. 

Im making this draft public, just to have a record of the work. 
Id like to maybe get this addon working for Cata in the future if I can find a good modular way of loading in data from different game versions cleanly.

Alot of the locale specific information for dungeons can be queried via the ingame api `GetLFGDungeonInfo` and a `DungeonID` 
(https://wago.tools/db2/LFGDungeons?build=1.15.2.54332&page=1&sort[ID]=asc)

I think this should be used going forward to fill any holes in the manual translations that have been done up to this point.

Some manual translations will still be required.