### PR TITLE
fix: `TableCopy` reference to global `RAID_CLASS_COLORS` to prevent taint.

### DIFF
--- a/LFGBulletinBoard/LibGPIToolBox.lua
+++ b/LFGBulletinBoard/LibGPIToolBox.lua
@@ -50,7 +50,7 @@ Tool.RoleIcon = {
   
 Tool.Classes=CLASS_SORT_ORDER
 Tool.ClassName=LOCALIZED_CLASS_NAMES_MALE
-Tool.ClassColor=RAID_CLASS_COLORS
+Tool.ClassColor = CopyTable(RAID_CLASS_COLORS)
 -- support for CUSTOM_CLASS_COLORS
 if CUSTOM_CLASS_COLORS then
 	for k, v in pairs(CUSTOM_CLASS_COLORS) do


### PR DESCRIPTION
Related Issues:
 - https://legacy.curseforge.com/wow/addons/lfg-group-finder-bulletin-board?comment=623
 
Taint occurs on line 61 where global table data was modified with `Tool.ClassColor[k] = v;` whenever `CUSTOM_CLASS_COLORS` existed.