### PR TITLE
fix: `SetClampedToScreen` to `true` for `GroupBulletinBoardFrame`

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -398,7 +398,7 @@ end
 
 function GBB.Init()
 	GroupBulletinBoardFrame:SetResizeBounds(400,170)	
-	
+	GroupBulletinBoardFrame:SetClampedToScreen(true)
 	GBB.UserLevel=UnitLevel("player")
 	GBB.UserName=(UnitFullName("player"))
 	GBB.ServerName=GetRealmName()


### PR DESCRIPTION
Related Issues:
 - #224 
 - #212 

Setting this value prevents the frame from being dragged/growing out of screen.