### PR TITLE
Added window reset position button on the regular setting

### DIFF
--- a/LFGBulletinBoard/Localization.lua
+++ b/LFGBulletinBoard/Localization.lua
@@ -115,6 +115,7 @@ GBB.locales = {
 		["BtnPlayerNoteColor"]="Color of the player note",
 		["BtnColorGuild"]="Colour of the guild text",
 		["BtnPostMsg"] = "Post",
+		["BtnResetWindow"]="Reset Window Position",
 
 		["SlashReset"]="Reset main window position",
 		["SlashConfig"]="Open configuration",
@@ -352,6 +353,8 @@ GBB.locales = {
 	["BtnPlayerNoteColor"]="Couleur de la note du joueur",
 	["BtnColorGuild"]="Couleur du texte de la guilde",
 	["BtnPostMsg"] = "Poster",
+	["BtnResetWindow"]="Reset Window Position",
+
 	["SlashReset"]="Réinitialiser la position de la fenêtre principale",
 	["SlashConfig"]="Ouvrir la configuration",
 	["SlashDefault"]="Ouvrir la fenêtre principale",
@@ -382,6 +385,8 @@ GBB.locales = {
 		["BtnNotifyColor"]="Цвет уведомительного сообщения",
 		["BtnSelectAll"]="Выбрать все",
 		["BtnPostMsg"]="Объявить",
+		["BtnResetWindow"]="Reset Window Position",
+
 		["BtnStopAnnounceMsg"]="Остановить автоматическое объявление",
 		["BtnTimeColor"]="Цвет времени",
 		["BtnPlayerNoteColor"]="Цвет заметки об игроке",
@@ -585,6 +590,7 @@ GBB.locales = {
 		["BtnPlayerNoteColor"]="玩家註記顏色",
 		["BtnColorGuild"]="公會文字顏色",
 		["BtnPostMsg"] = "發佈",
+		["BtnResetWindow"]="Reset Window Position",
 
 		["SlashReset"]="重設主視窗位置",
 		["SlashConfig"]="開啟設定",
@@ -714,6 +720,7 @@ GBB.locales = {
 		["BtnPlayerNoteColor"]="玩家姓名颜色",
 		["BtnColorGuild"]="公会文字颜色",
 		["BtnPostMsg"] = "发布",
+		["BtnResetWindow"]="Reset Window Position",
 
 		["SlashReset"]="重设主窗口位置",
 		["SlashConfig"]="开启设置",

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -231,6 +231,10 @@ function GBB.OptionsInit ()
 	GBB.Options.Indent(-30)
 	GBB.Options.AddSpace()
 	CheckBox("OnDebug",false)
+
+	GBB.Options.AddSpace()
+	GBB.Options.AddButton(GBB.L["BtnResetWindow"],GBB.ResetWindow)
+	GBB.Options.AddSpace()
 	----
 	-- Second Panel for Wotlk Dungeons
 


### PR DESCRIPTION
 - Followed by comment from https://github.com/Vysci/LFG-Bulletin-Board/pull/227
   - The quick access setting on the minimap is misplaced and should be relocated to the regular settings, as it's not an option that needs to be frequently changed.
   - And it has been mentioned how to reset the window with command ```/gbb reset``` in about section in the regular settings, it might still be hard for users to find.


Code changed
 - Added button on the bottom of the regular setting menu
 - Added Localization property  "BtnResetWindow" on each locales
 

 Test
 - Click on "Reset Window Position" button on the regular setting menu
   1. Reseted ether opened or closed window.
   2. Close popup-menu after close.
   3. No Lua error caused.

![Screenshot 2024-05-05 164538](https://github.com/Vysci/LFG-Bulletin-Board/assets/128768603/9a725fb0-21ab-48f4-8087-e665121e0b85)
