### PR TITLE
Added reset position button on the regular setting

### DIFF
--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -237,6 +237,11 @@ function GBB.OptionsInit ()
 	GBB.Options.Indent(-30)
 	GBB.Options.AddSpace()
 	CheckBox("OnDebug",false)
+
+	GBB.Options.AddSpace()
+	-- a global framexml string that's pre translated by blizzard called RESET_POSITION
+	GBB.Options.AddButton(RESET_POSITION,GBB.ResetWindow)
+	GBB.Options.AddSpace()
 	----
 	-- Second Panel for Wotlk Dungeons
 


### PR DESCRIPTION
 - Followed by comment from https://github.com/Vysci/LFG-Bulletin-Board/pull/227
   - The quick access setting on the minimap is misplaced and should be relocated to the regular settings, as it's not an option that needs to be frequently changed.
   - And it has been mentioned how to reset the window with command ```/gbb reset``` in about section in the regular settings, it might still be hard for users to find.
   - Used GlobalStrings "RESET_POSITION": https://github.com/Vysci/LFG-Bulletin-Board/pull/230#issuecomment-2094916287


Code changed
 - Added button on the bottom of the regular setting menu


 Test
 - Click on "Reset Position" button on the regular setting menu
   1. Reseted ether opened or closed window.
   2. Close popup-menu after close.
   3. No Lua error caused.

![Screenshot 2024-05-07 164535](https://github.com/Vysci/LFG-Bulletin-Board/assets/128768603/84c0d2b0-470f-4ccc-a87b-279b6087d1a2)


 - in the other locale(Korean)
![Screenshot 2024-05-07 164310](https://github.com/Vysci/LFG-Bulletin-Board/assets/128768603/23ce4468-0586-42f8-85fa-87cdb1dd23fb)
