### PR TITLE
fix: update hardcoded sizing in `GBB.ResetWindow`

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -211,8 +211,7 @@ end
 function GBB.ResetWindow()
 	GroupBulletinBoardFrame:ClearAllPoints()
 	GroupBulletinBoardFrame:SetPoint("Center", UIParent, "Center", 0, 0)
-	GroupBulletinBoardFrame:SetWidth(300)
-	GroupBulletinBoardFrame:SetHeight(170)
+	GroupBulletinBoardFrame:SetSize(GroupBulletinBoardFrame:GetResizeBounds())
 	GBB.SaveAnchors()
 	GBB.ResizeFrameList()
 end


### PR DESCRIPTION
Fixes a small visual issue where the `/gbb reset` or `Reset Position` button would over-shrink the window causing the searchbar to overflow

**Images**:
(Before)
![before](https://github.com/Vysci/LFG-Bulletin-Board/assets/20932280/a6f6ff3c-25d0-4ec5-a492-a6306eab3af9)

(After)
![after](https://github.com/Vysci/LFG-Bulletin-Board/assets/20932280/e7225f46-8533-41b3-8a8f-8e97c6272827)

