### PR TITLE
rework: dungeon data client specific modules

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -760,7 +760,7 @@ end
 GBB.PvpSodNames = pvpNames
 
 -- used in Tags.lua for determining which tags are safe for game version
-GBB.VanillaDungeonNames = GBB.GetSortedDungeonKeys(
+GBB.VanillaDungeonKeys = GBB.GetSortedDungeonKeys(
 	GBB.Enum.Expansions.Classic,
 	{ GBB.Enum.DungeonType.Dungeon, GBB.Enum.DungeonType.Raid }
 );
@@ -791,9 +791,9 @@ function GBB.GetDungeonSort()
 		end
     end
 
-	local dungeonOrder = { GBB.VanillaDungeonNames, tbcDungeonNames, wotlkDungeonNames, pvpNames, GBB.Misc, debugNames}
+	local dungeonOrder = { GBB.VanillaDungeonKeys, tbcDungeonNames, wotlkDungeonNames, pvpNames, GBB.Misc, debugNames}
 
-	local vanillaDungeonSize = #GBB.VanillaDungeonNames
+	local vanillaDungeonSize = #GBB.VanillaDungeonKeys
 
 	local tbcDungeonSize = GetSize(tbcDungeonNames)
 

--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -756,9 +756,6 @@ function GBB.GetRaids()
 	return arr
 end
 
--- used in Tags.lua atm for determining which tags are safe for game version
-GBB.PvpSodNames = pvpNames
-
 -- used in Tags.lua for determining which tags are safe for game version
 GBB.VanillaDungeonKeys = GBB.GetSortedDungeonKeys(
 	GBB.Enum.Expansions.Classic,

--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -757,6 +757,7 @@ function GBB.GetRaids()
 end
 
 -- used in Tags.lua for determining which tags are safe for game version
+-- used in Options.lua for determining adding filter boxes
 GBB.VanillaDungeonKeys = GBB.GetSortedDungeonKeys(
 	GBB.Enum.Expansions.Classic,
 	{ GBB.Enum.DungeonType.Dungeon, GBB.Enum.DungeonType.Raid }

--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -778,14 +778,27 @@ GBB.Seasonal = {
 	["HOLLOW"] = { startDate = "10/18", endDate = "11/01"}
 }
 
--- hack, include ONY in classic era; add before BWL
+-- hack: need to add "ONY" and "NAXX"
 if isClassicEra then
+	-- remove this hack when updating dungeon name generation to the new data pipeline.
+	-- include ONY in classic era; add before BWL
 	for sortIdx = (#GBB.VanillDungeonNames), 1, -1 do
 		if GBB.VanillDungeonNames[sortIdx] == "BWL" then
 			table.insert(GBB.VanillDungeonNames, sortIdx, "ONY")
 			break
 		end
 	end
+	
+	-- Tags.lua expects to use the key "NAXX" not "NAX"
+	for sortIdx = (#GBB.VanillDungeonNames), 1, -1 do
+		if GBB.VanillDungeonNames[sortIdx] == "NAX" then
+			GBB.VanillDungeonNames[sortIdx] = "NAXX"
+		end
+	end
+	
+	-- clear unused dungeons in classic to not generate options/checkboxes
+	wotlkDungeonNames = {}
+	tbcDungeonNames = {}
 end
 
 function GBB.GetDungeonSort()
@@ -797,19 +810,6 @@ function GBB.GetDungeonSort()
 		end
     end
 
-	if isClassicEra then 
-		-- todo: add "Ony"
-		-- hack to remove dungeons from classic ui
-		wotlkDungeonNames = {}
-		tbcDungeonNames = {}
-		-- replace "NAX" with "NAXX" for the classic era
-		-- (this is to use the appropriate tags)
-		for i, key in ipairs(GBB.VanillDungeonNames) do
-			if key == "NAX" then
-				GBB.VanillDungeonNames[i] = "NAXX"
-			end
-		end
-	end
 	local dungeonOrder = { GBB.VanillDungeonNames, tbcDungeonNames, wotlkDungeonNames, pvpNames, GBB.Misc, debugNames}
 
 	-- Why does Lua not having a fucking size function
@@ -861,7 +861,5 @@ if isClassicEra then
 	local dungeonLevels = GBB.GetDungeonLevelRanges()
 	-- needed because Option.lua hardcodes a checkbox for "DEADMINES"
 	dungeonLevels["DEADMINES"] = dungeonLevels["DM"]
-	-- needed because dungeons/classic.lua uses "NAXX" instead of "NAX"
-	dungeonLevels["NAX"] = dungeonLevels["NAXX"]
 	GBB.dungeonLevel = mergeTables(dungeonLevels, miscCatergoriesLevels)
 end

--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -637,16 +637,16 @@ local function mergeTables(...)
 end
 
 -- Generated in /data/dungeons/
-local vanillaDungeonLevels = {
-	["RFC"] = 	{13,18}, ["DM"] = 	{18,23}, ["WC"] = 	{15,25}, ["SFK"] = 	{22,30}, ["STK"] = 	{22,30}, ["BFD"] = 	{24,32},
-	["GNO"] = 	{29,38}, ["RFK"] = 	{30,40}, ["SMG"] = 	{28,38}, ["SML"] = 	{29,39}, ["SMA"] = 	{32,42}, ["SMC"] = 	{35,45},
-	["RFD"] = 	{40,50}, ["ULD"] = 	{42,52}, ["ZF"] = 	{44,54}, ["MAR"] = 	{46,55}, ["ST"] = 	{50,60}, ["BRD"] = 	{52,60},
-	["LBRS"] = 	{55,60}, ["DME"] = 	{58,60}, ["DMN"] = 	{58,60}, ["DMW"] = 	{58,60}, ["STR"] = 	{58,60}, ["SCH"] = 	{58,60},
-	["UBRS"] = 	{58,60}, ["MC"] = 	{60,60}, ["ZG"] = 	{60,60}, ["AQ20"]= 	{60,60}, ["BWL"] = {60,60},
-	["AQ40"] = 	{60,60}, ["NAX"] = 	{60,60},
-	["MISC"]=   {0,100}, ["TRAVEL"]={0,100}, ["INCUR"]={0,100},
-	["DEBUG"] = {0,100}, ["BAD"] =	{0,100}, ["TRADE"]=	{0,100}, ["SM2"] =  {28,42}, ["DM2"] =	{58,60}, ["DEADMINES"]={18,23},
-}
+-- local vanillaDungeonLevels = {
+-- 	["RFC"] = 	{13,18}, ["DM"] = 	{18,23}, ["WC"] = 	{15,25}, ["SFK"] = 	{22,30}, ["STK"] = 	{22,30}, ["BFD"] = 	{24,32},
+-- 	["GNO"] = 	{29,38}, ["RFK"] = 	{30,40}, ["SMG"] = 	{28,38}, ["SML"] = 	{29,39}, ["SMA"] = 	{32,42}, ["SMC"] = 	{35,45},
+-- 	["RFD"] = 	{40,50}, ["ULD"] = 	{42,52}, ["ZF"] = 	{44,54}, ["MAR"] = 	{46,55}, ["ST"] = 	{50,60}, ["BRD"] = 	{52,60},
+-- 	["LBRS"] = 	{55,60}, ["DME"] = 	{58,60}, ["DMN"] = 	{58,60}, ["DMW"] = 	{58,60}, ["STR"] = 	{58,60}, ["SCH"] = 	{58,60},
+-- 	["UBRS"] = 	{58,60}, ["MC"] = 	{60,60}, ["ZG"] = 	{60,60}, ["AQ20"]= 	{60,60}, ["BWL"] = {60,60},
+-- 	["AQ40"] = 	{60,60}, ["NAX"] = 	{60,60},
+-- 	["MISC"]=   {0,100}, ["TRAVEL"]={0,100}, ["INCUR"]={0,100},
+-- 	["DEBUG"] = {0,100}, ["BAD"] =	{0,100}, ["TRADE"]=	{0,100}, ["SM2"] =  {28,42}, ["DM2"] =	{58,60}, ["DEADMINES"]={18,23},
+-- }
 
 local postTbcDungeonLevels = {
 	["RFC"] = 	{13,20}, ["DM"] = 	{16,24}, ["WC"] = 	{16,24}, ["SFK"] = 	{17,25}, ["STK"] = 	{21,29}, ["BFD"] = 	{20,28},
@@ -798,6 +798,7 @@ function GBB.GetDungeonSort()
     end
 
 	if isClassicEra then 
+		-- todo: add "Ony"
 		-- hack to remove dungeons from classic ui
 		wotlkDungeonNames = {}
 		tbcDungeonNames = {}
@@ -854,3 +855,13 @@ local function DetermineVanillDungeonRange()
 end
 
 GBB.dungeonLevel = mergeTables(DetermineVanillDungeonRange(), tbcDungeonLevels, wotlkDungeonLevels, pvpLevels)
+
+if isClassicEra then
+	-- includes valid dungeons/raids/bgs
+	local dungeonLevels = GBB.GetDungeonLevelRanges()
+	-- needed because Option.lua hardcodes a checkbox for "DEADMINES"
+	dungeonLevels["DEADMINES"] = dungeonLevels["DM"]
+	-- needed because dungeons/classic.lua uses "NAXX" instead of "NAX"
+	dungeonLevels["NAX"] = dungeonLevels["NAXX"]
+	GBB.dungeonLevel = mergeTables(dungeonLevels, miscCatergoriesLevels)
+end

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -813,7 +813,7 @@ function GBB.OnUpdate(elapsed)
 		end;
 
 		if GBB.ElapsedSinceLfgUpdate > 18 and GBB.Tool.GetSelectedTab(GroupBulletinBoardFrame)==2 and GroupBulletinBoardFrame:IsVisible() then
-			LFGBrowseFrameRefreshButton:Click()
+			-- LFGListFrame.SearchPanel.RefreshButton:Click() -- hwevent protected
 			GBB.UpdateLfgTool()
 			GBB.ElapsedSinceLfgUpdate = 0
 		else

--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -11,6 +11,7 @@ LibGPIMinimapButton.lua
 LibGPIToolBox.lua
 Chat.lua
 Localization.lua
+dungeons/classic.lua
 Dungeons.lua
 Tags.lua
 RequestList.lua

--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -12,6 +12,7 @@ LibGPIToolBox.lua
 Chat.lua
 Localization.lua
 dungeons/classic.lua
+dungeons/cata.lua
 Dungeons.lua
 Tags.lua
 RequestList.lua

--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -1,4 +1,4 @@
-## Interface: 11502
+## Interface: 11502, 40400
 ## Title: LFG Bulletin Board
 ## Notes: Sort LFG/LFM Messages
 ## Version: 3.24

--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -208,34 +208,34 @@ function GBB.GetLfgList()
 end
 
 function GBB.UpdateLfgTool()
-    if LFGBrowseFrame and LFGBrowseFrame.CategoryDropDown.selectedValue == 120 then return end
-    if  LFGBrowseFrame and LFGBrowseFrame.CategoryDropDown.selectedValue == nil then  
-        LFGBrowseFrame.CategoryDropDown.selectedValue = 2
+    if LFGListFrame and LFGListFrame.CategorySelection.selectedCategory == 120 then return end
+    if  LFGListFrame and LFGListFrame.CategorySelection.selectedCategory == nil then  
+        LFGListFrame.CategorySelection.selectedCategory = 2
     end
 
     LastUpdateTime = time()
     GBB.LfgRequestList = {}
     
     local category = 2
-    if LFGBrowseFrame and LFGBrowseFrame.CategoryDropDown.selectedValue ~= nil then 
-        category = LFGBrowseFrame.CategoryDropDown.selectedValue
+    if LFGListFrame and LFGListFrame.CategorySelection.selectedCategory ~= nil then 
+        category = LFGListFrame.CategorySelection.selectedCategory
     end
 
 	local activities = C_LFGList.GetAvailableActivities(category)
 	--C_LFGList.Search(category, activities)
-    if LFGBrowseFrame and LFGBrowseFrame.searching then return end
+    if LFGListFrame and LFGListFrame.searching then return end
 
 	GBB.GetLfgList()
     GBB.LfgUpdateList()
 end
 
 function GBB.UpdateLfgToolNoSearch()
-    if LFGBrowseFrame.CategoryDropDown.selectedValue == 120 then return end
-    if  LFGBrowseFrame.CategoryDropDown.selectedValue == nil then  
-        LFGBrowseFrame.CategoryDropDown.selectedValue = 2
+    if LFGListFrame.CategorySelection.selectedCategory == 120 then return end
+    if  LFGListFrame.CategorySelection.selectedCategory == nil then  
+        LFGListFrame.CategorySelection.selectedCategory = 2
     end
 
-if LFGBrowseFrame.searching then return end
+if LFGListFrame and LFGListFrame.searching then return end
 
     GBB.LfgRequestList = {}
     GBB.GetLfgList()

--- a/LFGBulletinBoard/LibGPIOptions.lua
+++ b/LFGBulletinBoard/LibGPIOptions.lua
@@ -184,7 +184,7 @@ end
 	
 function Options.SetRightSide(w)
 	Options.NextRelativ=Options.Prefix.."OptionFrame".. #Options.Panel .."_Title"
-	Options.NextRelativX=310 / Options.scale
+	Options.NextRelativX= (w or 310) / Options.scale
 	Options.NextRelativY=0
 end
 	

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -2,6 +2,7 @@ local TOCNAME,GBB=...
 local ChannelIDs
 local ChkBox_FilterDungeon
 local TbcChkBox_FilterDungeon
+local isClassicEra = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
 --Options
 -------------------------------------------------------------------------------------
 
@@ -243,12 +244,9 @@ function GBB.OptionsInit ()
 	GBB.Options.AddButton(RESET_POSITION,GBB.ResetWindow)
 	GBB.Options.AddSpace()
 	----
+	
 	-- Second Panel for Wotlk Dungeons
-
-
-
-	local version, build, date, tocversion = GetBuildInfo()
-	if string.sub(version, 1, 2) ~= "1." then
+	if not isClassicEra then
 
 		GBB.Options.AddPanel(GBB.L["WotlkPanelFilter"])
 		GBB.Options.AddCategory(GBB.L["HeaderDungeon"])
@@ -338,16 +336,15 @@ function GBB.OptionsInit ()
 		ChkBox_FilterDungeon[index]=CheckBoxFilter(GBB.dungeonSort[index],true)
 	end
 
-	if string.sub(version, 1, 2) == "1." then
+	if isClassicEra then
 		for index=GBB.ENDINGDUNGEONSTART,GBB.ENDINGDUNGEONEND do
 			ChkBox_FilterDungeon[index]=CheckBoxFilter(GBB.dungeonSort[index],true)
 		end
 	end
 	--GBB.Options.AddSpace()
 
-	
 	--GBB.Options.AddSpace()
-	if string.sub(version, 1, 2) == "1." then
+	if isClassicEra then
 		CheckBoxChar("FilterLevel",false)
 		CheckBoxChar("DontFilterOwn",false)
 		CheckBoxChar("HeroicOnly", false)
@@ -364,10 +361,11 @@ function GBB.OptionsInit ()
 	end)
 	GBB.Options.EndInLine()
 	GBB.Options.Indent(-10)
-	if string.sub(version, 1, 2) == "1." then
+	if isClassicEra then
 		SetChatOption()
 		
 	end
+
 	-- Tags
 	GBB.Options.AddPanel(GBB.L["PanelTags"],false,true)
 	

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -593,7 +593,7 @@ if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
 
 	-- Collect tags valid for vanilla
 	local validDungeons = {}
-	for _, key in ipairs(GBB.VanillDungeonNames) do
+	for _, key in ipairs(GBB.VanillaDungeonNames) do
 		validDungeons[key] = true
 	end
 	-- using PvPSodNames just coz it already only has the classic bgs

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -593,7 +593,7 @@ if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
 
 	-- Collect tags valid for vanilla
 	local validDungeons = {}
-	for _, key in ipairs(GBB.VanillaDungeonNames) do
+	for _, key in ipairs(GBB.VanillaDungeonKeys) do
 		validDungeons[key] = true
 	end
 	-- using PvPSodNames just coz it already only has the classic bgs

--- a/LFGBulletinBoard/dungeons/cata.lua
+++ b/LFGBulletinBoard/dungeons/cata.lua
@@ -1,0 +1,474 @@
+---@diagnostic disable: duplicate-set-field
+local tocName, 
+    ---@class Addon_DungeonData
+    addon = ...;
+if WOW_PROJECT_ID ~= WOW_PROJECT_CATACLYSM_CLASSIC then return end
+assert(GetLFGDungeonInfo, tocName .. " requires the API `GetLFGDungeonInfo` for parsing dungeon info")
+assert(GetRealZoneText, tocName .. " requires the API `GetRealZoneText` for parsing dungeon info")
+assert(C_LFGList.GetActivityInfoTable, tocName .. " requires the API `C_LFGList.GetActivityInfoTable` for parsing dungeon info")
+
+local debug = false
+local print = function(...) if debug then addon.print(...) end end
+
+-- initialize here for now, this should be moved to a file thats always grunted to load first.
+addon.Enum = addon.Enum or {} 
+local Expansions = {
+	Classic = 0,
+	BurningCrusade = 1,
+	Wrath = 2,
+	Cataclysm = 3,
+}
+
+local DungeonType = {
+	Dungeon = 1,
+	Raid = 2,
+	Zone = 4,
+    -- Possible to use 5 for BG's but i want to preserve the ID just incase
+	Random = 6,
+	Battleground = 7
+}
+-- The keys to this table need to be manually matched to the appropriate dungeonID
+-- These same keys are used for identifying the preset tags/keywords for each dungeon. If a tags Key is missing from this table, the tags will not be registered.
+-- modifications here should be reflected in the `Tags.lua` file and vice versa.
+local LFGDungeonIDs = {
+	NULL = 358,	-- 10v10 Rated Battleground (RBG)
+	AQ20 = 160,	-- Ahn'Qiraj Ruins
+	AQ40 = 161,	-- Ahn'Qiraj Temple
+	ANK = 218,	-- Ahn'kahet: The Old Kingdom
+	CRYPTS = 149,	-- Auchenai Crypts
+	AZN = 204,	-- Azjol-Nerub
+	NULL = 328,	-- Baradin Hold
+	BT = 196,	-- Black Temple
+	BFD = 10,   -- Blackfathom Deeps
+	NULL = 303,	-- Blackrock Caverns
+	
+	-- These get put into "BRD"
+	NULL = 30,  -- Blackrock Depths - Detention Block
+	NULL = 276,	-- Blackrock Depths - Upper City
+	
+	NULL = 313,	-- Blackwing Descent
+	BWL = 50,   -- Blackwing Lair
+	BF = 137,	-- Blood Furnace
+	DM = 6,     -- Deadmines
+
+	DM2 = 33,   -- Base Dire Maul (Spoofed entry see infoOverrides)
+	DME = 34,	-- Dire Maul - East (Renamed in Cata)
+	DMN = 38,	-- Dire Maul - North (Renamed in Cata)
+	DMW = 36,	-- Dire Maul - West (Renamed in Cata)
+	NULL = 447,	-- Dragon Soul
+	DTK = 214,	-- Drak'Tharon Keep
+	NULL = 435,	-- End Time
+	NULL = 417,	-- Fall of Deathwing
+	NULL = 361,	-- Firelands
+	GNO = 14,   -- Gnomeregan
+	NULL = 304,	-- Grim Batol
+	GL = 177,	-- Gruul's Lair
+	GD = 216,	-- Gundrak
+	HOL = 207,	-- Halls of Lightning
+	NULL = 305,	-- Halls of Origination
+	HOR = 255,	-- Halls of Reflection
+	HOS = 208,	-- Halls of Stone
+	RAMPS = 136,-- Hellfire Ramparts
+	NULL = 439,	-- Hour of Twilight
+	HYJAL = 195,-- Hyjal Past
+	ICC = 279,	-- Icecrown Citadel
+	KARA = 175,	-- Karazhan
+	NULL = 312,	-- Lost City of the Tol'vir
+	LBRS = 32,  -- Lower Blackrock Spire
+	MGT = 198,	-- Magisters' Terrace
+	MAG = 176,	-- Magtheridon's Lair
+	MT = 148,	-- Mana-Tombs
+	
+    -- all these can get put into "MAR" or split into MAR1, MAR2, MAR3
+	-- NULL = 273,	-- Maraudon - Earth Song Falls
+	-- NULL = 26,  -- Maraudon - Foulspore Cavern
+	-- NULL = 272,	-- Maraudon - The Wicked Grotto
+	MAR = { 273, 26, 272 },
+	
+	MC = 48,    -- Molten Core
+	NAXX = 159,	-- Naxxramas
+	ONY = 46,   -- Onyxia's Lair
+	BM = 171,	-- Opening of the Dark Portal (See Black Morass in ActivityIDs)
+	POS = 253,	-- Pit of Saron
+    RFC = 4,    -- Ragefire Chasm
+	RFD = 20,   -- Razorfen Downs
+	RFK = 16,   -- Razorfen Kraul
+	RS = 293,	-- Ruby Sanctum
+	
+	-- base Scarlet Monastery not a real LFGDungeonEntry (spoofed in infoOverrides)
+	SM2 = 17,  	
+	SMA = 163,	-- Scarlet Monastery - Armory
+	SMC = 164,	-- Scarlet Monastery - Cathedral
+	SMG = 18,   -- Scarlet Monastery - Graveyard
+	SML = 165,	-- Scarlet Monastery - Library
+	
+	SCH = 2,    -- Scholomance
+	SSC = 194,	-- Serpentshrine Cavern
+	SETH = 150,	-- Sethekk Halls
+	SL = 151,	-- Shadow Labyrinth
+	SFK = 8,    -- Shadowfang Keep
+	SH = 138,	-- Shattered Halls
+	SP = 140,	-- Slave Pens
+	STK = 12,   -- Stormwind Stockade
+
+	-- These can get group in "STR"
+	NULL = 40,  -- Stratholme - Main Gate
+	NULL = 274,	-- Stratholme - Service Entrance
+
+	ST = 28,    -- Sunken Temple
+	EYE = 193,	-- Tempest Keep (The Eye)
+	ARC = 174,	-- The Arcatraz
+	NULL = 315,	-- The Bastion of Twilight
+	BOT = 173,	-- The Botanica
+	COS = 209,	-- The Culling of Stratholme
+	OHB = 170,	-- The Escape From Durnholde (Old Hillsbrad Foothills)
+	EOE = 223,	-- The Eye of Eternity
+	FOS = 251,	-- The Forge of Souls
+	MECH = 172,	-- The Mechanar
+	NEX = 225,	-- The Nexus
+	OS = 224,	-- The Obsidian Sanctum
+	OCC = 206,	-- The Oculus
+	NULL = 416,	-- The Siege of Wyrmrest Temple
+	SV = 147,	-- The Steamvault
+	NULL = 307,	-- The Stonecore
+	SWP = 199,	-- The Sunwell
+	NULL = 311,	-- The Vortex Pinnacle
+	NULL = 317,	-- Throne of the Four Winds
+	NULL = 302,	-- Throne of the Tides
+	CHAMP = 245,-- Trial of the Champion
+	TOTC = {
+		246,	-- Trial of the Crusader
+	    247,	-- Trial of the Grand Crusader
+    },
+	ULD = 22,   -- Uldaman
+	ULDAR = 243,-- Ulduar
+	UB = 146,	-- Underbog
+	UBRS = 330,	-- Upper Blackrock Spire
+	UK = 202,	-- Utgarde Keep
+	UP = 203,	-- Utgarde Pinnacle
+	VOA = 239,	-- Vault of Archavon
+	VH = 220,	-- Violet Hold
+	WC = 1,     -- Wailing Caverns
+	NULL = 437,	-- Well of Eternity
+	ZA = 340,	-- Zul'Aman
+	ZF = 24,    -- Zul'Farrak
+	ZG = 334,	-- Zul'Gurub 
+
+	-- Seasonal
+	BREW = 287,	-- Coren Direbrew (Brewfest)
+	NULL = 288,	-- The Crown Chemical Co. (Love is in the Air)
+	NULL = 286,	-- The Frost Lord Ahune (Midsummer)
+	HOLLOW = 285,	-- The Headless Horseman (Hallow's End)
+
+	-- Cata prepatch bosses
+	EARTH_PORTAL = 297,	-- Crown Princess Theradras
+	FIRE_PORTAL = 296,	-- Grand Ambassador Flamelash
+	WATER_PORTAL = 298,	-- Kai'ju Gahz'rilla
+	AIR_PORTAL = 299,	-- Prince Sarsarun
+}
+local dungeonIDToKey = {}
+for key, dungeonID in pairs(LFGDungeonIDs) do
+    if type(dungeonID) == "table" then
+        for _, id in ipairs(dungeonID) do
+            dungeonIDToKey[id] = key
+        end
+    else
+        dungeonIDToKey[dungeonID] = key
+    end
+end
+-- Following have no DungeonID in cata client so use a related ActivityID
+-- https://wago.tools/db2/GroupFinderActivity?build=4.4.0.54525
+local ActivityIDs = {
+    ARENA = {
+        936,    -- 2v2 Arena
+        937,    -- 3v3 Arena
+        938     -- 5v5 Arena
+    },
+	AV = 932,	-- Alterac Valley
+	AB = 926,	-- Arathi Basin
+	BRD = 811,	-- Blackrock Depths 
+	EOTS = 934,	-- Eye of the Storm
+	NULL = 1144,	-- Isle of Conquest
+	SOTA = 1142,	-- Strand of the Ancients
+	STR = 816,	-- Stratholme
+	-- BM = 831,	-- The Black Morass (only used in overrides)
+	WSG = 919,	-- Warsong Gulch
+	WG = 1117, -- Wintergrasp
+    -- MARA = 809,	-- Maraudon (now split into 3 wings)
+	-- STK = 802,	-- Stormwind Stockades (Use "Stormwind Stockade")
+	-- UB = 821,	-- Coilfang - Underbog (Just use Underbog)
+	-- DME = 813,	-- Dire Maul - East (Renamed in Cata)
+	-- DMN = 815,	-- Dire Maul - North (Renamed in Cata)
+	-- DMW = 814,	-- Dire Maul - West (Renamed in Cata)
+	-- Battle for Tol Barad missing
+	-- Twin Peaks missing
+}
+local activityIDToKey = {}
+for key, activityID in pairs(ActivityIDs) do
+    if type(activityID) == "table" then
+        for _, id in ipairs(activityID) do
+            activityIDToKey[id] = key
+        end
+    else
+        activityIDToKey[activityID] = key
+    end
+end
+
+-- C_LFGList.GetActivityInfoTable doesnt have expansionID so we need to set it based on activityGroupID
+-- https://wago.tools/db2/GroupFinderActivityGrp?build=4.4.0.54525
+local groupIDAdditionalInfo = {
+	[285] = { -- Classic Dungeons
+		expansionID = Expansions.Classic, 
+		typeID = DungeonType.Dungeon,
+	},
+	[290] = { -- Classic Raids
+		expansionID = Expansions.Classic, 
+		typeID = DungeonType.Raid,
+	},
+	[286] = { -- Burning Crusade Dungeons
+		expansionID = Expansions.BurningCrusade,
+		typeID = DungeonType.Dungeon,
+	},
+	[291] = { -- Burning Crusade Raids
+		expansionID = Expansions.BurningCrusade, 
+		typeID = DungeonType.Raid,
+	}, 
+	[287] = { -- Lich King Dungeons
+		expansionID = Expansions.Wrath,
+		typeID = DungeonType.Dungeon,
+	},
+	[292] = {-- Lich King Raids
+		expansionID = Expansions.Wrath, 
+		typeID = DungeonType.Raid,
+	},
+
+	-- note: no Cataclysm Dungeons entry in the db table
+	[364] = { -- Cataclysm Raids
+		expansionID = Expansions.Cataclysm,
+		typeID = DungeonType.Raid,
+	}, 
+	-- Arena & Battlegrounds (map to latest expansion)
+	[299] = {
+		expansionID = Expansions.Cataclysm,
+		typeID = DungeonType.Battleground,
+	}
+}
+do -- map IDs to ones that share expansion and type data
+	local groupIdMap = {
+		[288] = 286, -- Burning Crusade Heroic Dungeons
+		[289] = 287, -- Lich King Heroic Dungeons
+		[293] = 292, -- Lich King Normal Raids (25)
+		[320] = 292, -- Lich King Heroic Raids (10)
+		[321] = 292, -- Lich King Heroic Raids (25)
+		[300] = 299, -- Battlegrounds
+		[301] = 299, -- World PvP Events
+	}
+	for link, source in pairs(groupIdMap) do
+		groupIDAdditionalInfo[link] = groupIDAdditionalInfo[source]
+	end
+end
+
+-- For any data that isnt available in either api, we can manually override it here.
+-- Either manually hardcoded or by using a different api to get the data.
+-- key by dungeonKey, `nil`/missing info entries will be ignored.
+local effectiveMaxLevel = GetEffectivePlayerMaxLevel()
+local infoOverrides = {
+	-- Most People know this dungeon as "black morass" but its officially called "Opening of the Dark Portal" in lfgdungeoninfo
+	BM = { name = DUNGEON_FLOOR_COTTHEBLACKMORASS1 },
+	-- Following dungeons have been splint into multiple wings in the cata client
+	-- take the min level from the first wing and max level from the second wing.
+	-- the ActivityInfo api also doesnt supply the dungeon type so we'll just hardcode it here.
+	SM2 = { 
+		name = GetRealZoneText(189), 
+		minLevel = 26, maxLevel = 45,
+		expansionID = Expansions.Classic,
+		typeID = DungeonType.Dungeon 
+	},
+	BRD = { minLevel = 49, maxLevel = 61 },
+	STR = { minLevel = 42, maxLevel = 56},
+	MAR = { 
+		name = GetRealZoneText(349), 
+		minLevel = 32, maxLevel = 44, 
+		typeID = DungeonType.Dungeon, 
+	},
+	DM2 = { 
+		name = GetRealZoneText(429), 
+		minLevel = 36, maxLevel = 52,
+		expansionID = Expansions.Classic,
+		typeID = DungeonType.Dungeon 
+	},
+	-- DME = { minLevel = 36, maxLevel = 46 },
+	-- DMW = { minLevel = 39, maxLevel = 49 },
+	-- DMN = { minLevel = 42, maxLevel = 52 },
+	-- The pvp dungeons arent in th LFGDungeons table in the cata client atm. (except for RBG)
+	-- and the GetActivityInfoTable API is returning `0` for min/max level so we'll just hardcode it here.
+	ARENA = { minLevel = 10, maxLevel = effectiveMaxLevel },
+	WSG = { minLevel = 10, maxLevel = effectiveMaxLevel },
+	AB = { minLevel = 10, maxLevel = effectiveMaxLevel },
+	EOTS = { minLevel = 35, maxLevel = effectiveMaxLevel },
+	AV = { minLevel = 45, maxLevel = effectiveMaxLevel },
+	SOTA = { minLevel = 65, maxLevel = effectiveMaxLevel },
+	WG = { minLevel = 71, maxLevel = effectiveMaxLevel },
+	RBG = { typeID = DungeonType.Battleground }, -- GetLFGDungeonInfo considers it a raid for some reason.
+	-- TB = { minLevel = effectiveMaxLevel, maxLevel = effectiveMaxLevel },
+
+}
+
+---@type {[DungeonID]: DungeonInfo}
+local dungeonInfoCache = {}
+local infoByTagKey = {}
+local numDungeons = 0
+do
+    local function cacheActivityInfo(activityID)
+        local cached = {}
+        local activityInfo = C_LFGList.GetActivityInfoTable(activityID)
+		local additionalInfo = groupIDAdditionalInfo[activityInfo.groupFinderActivityGroupID]
+        cached = {
+			name = activityInfo.shortName or activityInfo.fullName,
+            minLevel = activityInfo.minLevel,
+            maxLevel = activityInfo.maxLevel,
+			expansionID = additionalInfo.expansionID,
+			typeID = additionalInfo.typeID,
+            tagKey = activityIDToKey[activityID],
+        }
+		-- Note: this API seems to missing levels.
+		local overrides = infoOverrides[cached.tagKey]
+		if overrides then
+			for key, value in pairs(overrides) do
+				cached[key] = value
+			end
+		end
+		-- this is is here verify no overlap in ID's between LFGDungeonIDs and ActivityIDs
+        assert(not dungeonInfoCache[activityID], "Duplicate ID found for activity ID: " .. activityID, "Use a different dungeonID for this dungeon or different activityID", activityInfo)
+
+		assert(cached.name, "Failed to get name for activityID: " .. activityID, activityInfo)
+		assert(cached.minLevel and cached.maxLevel, "Failed to get level range for activityID: " .. activityID, activityInfo)
+		assert(cached.expansionID, "Failed to get expansionID for activityID: " .. activityID, activityInfo)
+		assert(cached.typeID, "Failed to get typeID for activityID: " .. activityID, activityInfo)
+
+        dungeonInfoCache[activityID] = cached
+		infoByTagKey[cached.tagKey] = cached
+        numDungeons = numDungeons + 1
+    end
+    local function cacheLFGDungeonInfo(dungeonID)
+        local cached = {}
+		-- https://warcraft.wiki.gg/wiki/API_GetLFGDungeonInfo
+        local dungeonInfo = {GetLFGDungeonInfo(dungeonID)}
+        local name, typeID, minLevel, maxLevel = 
+			dungeonInfo[1], dungeonInfo[2], dungeonInfo[4], dungeonInfo[5];
+        local expansionID, isHoliday = 
+			dungeonInfo[9], dungeonInfo[15];
+
+        cached = {
+            name = name,
+            minLevel = minLevel,
+            maxLevel = maxLevel,
+            typeID = typeID,
+            tagKey = dungeonIDToKey[dungeonID],
+			isHoliday = isHoliday,
+            expansionID = expansionID,
+        }
+		local overrides = infoOverrides[cached.tagKey]
+		if overrides then
+			for key, value in pairs(overrides) do
+				cached[key] = value
+			end
+		end
+		assert(not dungeonInfoCache[dungeonID], "Duplicate ID found for dungeon ID: " .. dungeonID, "Use a different dungeonID for this dungeon or different dungeonID", dungeonInfo)
+
+		assert(cached.name, "Failed to get name for dungeonID: " .. dungeonID, dungeonInfo)
+		assert(cached.minLevel and cached.maxLevel, "Failed to get level range for dungeonID: " .. dungeonID, dungeonInfo)
+		assert(cached.expansionID, "Failed to get expansionID for dungeonID: " .. dungeonID, dungeonInfo)
+		assert(cached.typeID, "Failed to get typeID for dungeonID: " .. dungeonID, dungeonInfo)
+
+        dungeonInfoCache[dungeonID] = cached
+        infoByTagKey[cached.tagKey] = cached
+		numDungeons = numDungeons + 1
+        -- print(_ .. ": Skipping dunegeon " .. info.name .. " dungeonID: " .. dungeonID .. " typeID: " .. info.typeID)
+    end
+    for dungeonKey in pairs(LFGDungeonIDs) do
+        local dungeonID = LFGDungeonIDs[dungeonKey]
+        if type(dungeonID) == "table" then
+            for _, id in ipairs(dungeonID) do
+                cacheLFGDungeonInfo(id)
+            end
+        else
+            cacheLFGDungeonInfo(dungeonID)
+        end
+    end
+    for activityKey in pairs(ActivityIDs) do
+        local activityID = ActivityIDs[activityKey]
+        if type(activityID) == "table" then
+            for _, id in ipairs(activityID) do
+                cacheActivityInfo(id)
+            end
+        else
+            cacheActivityInfo(activityID)
+        end
+    end
+end
+
+---@param dungeonKey string
+---@return (DungeonInfo|table<DungeonID, DungeonInfo>)? 
+function addon.GetDungeonInfo(dungeonKey, useRef)
+    if dungeonKey then
+        local info = infoByTagKey[dungeonKey]
+        if info then
+            return useRef and info or CopyTable(info)
+        end
+    end
+end
+
+--Optionally filter by expansionID and/or typeID
+---@param expansionID ExpansionID?
+---@param typeID DungeonTypeID|DungeonTypeID[]?
+function addon.GetSortedDungeonKeys(expansionID, typeID)
+	local keys = {}
+	for tagKey, info in pairs(infoByTagKey) do
+		if (not expansionID or info.expansionID == expansionID) 
+		and (not typeID 
+			or (type(typeID) == "number" and info.typeID == typeID)
+			or (type(typeID) == "table" and tContains(typeID, info.typeID)))
+		and (not info.isHoliday) -- ignore holidays for now. 
+		-- not actually dungeons
+		and (tagKey ~= "DM2" and tagKey ~= "SM2" and tagKey ~= "NULL")
+		then
+			tinsert(keys, tagKey)
+		end
+	end
+		table.sort(keys, function(keyA, keyB)
+		local infoA = infoByTagKey[keyA];
+        local infoB = infoByTagKey[keyB];
+        if infoA.typeID == infoB.typeID then
+            if infoA.minLevel == infoB.minLevel then
+                if infoA.maxLevel == infoB.maxLevel then
+                    if infoA.name == infoB.name then
+                        return keyA < keyB
+                    else return infoA.name < infoB.name end
+                else return infoA.maxLevel < infoB.maxLevel end
+            else return infoA.minLevel < infoB.minLevel end
+        else return infoA.typeID < infoB.typeID end
+	end)
+	return keys
+end
+
+---Optionally filter by expansionID and/or typeID
+---@param expansionID ExpansionID?
+---@param typeID DungeonTypeID?
+function addon.GetDungeonLevelRanges(expansionID, typeID)
+	local ranges = {}
+	for tagKey, info in pairs(infoByTagKey) do
+		if (not expansionID or info.expansionID == expansionID) 
+		and (not typeID or info.typeID == typeID) 
+		-- ignore NULL entries. But they really should be rectified at somepoint
+		and tagKey ~= "NULL"
+		then
+			ranges[tagKey] = {info.minLevel, info.maxLevel}
+		end
+	end
+	return ranges
+end
+
+addon.cataRawDungeonInfo = dungeonInfoCache
+addon.Enum.Expansions = Expansions
+addon.Enum.DungeonType = DungeonType

--- a/LFGBulletinBoard/dungeons/classic.lua
+++ b/LFGBulletinBoard/dungeons/classic.lua
@@ -1,0 +1,306 @@
+local tocName, 
+    ---@class Addon_DungeonData
+    addon = ...;
+    
+if WOW_PROJECT_ID ~= WOW_PROJECT_CLASSIC then return end
+---@alias DungeonID number
+---@alias ActivityID number
+
+---@class DungeonInfo
+---@field name string # Game client localized name of the dungeon
+---@field minLevel number
+---@field maxLevel number
+---@field typeID DungeonTypeID -- 1 = dungeon, 2 = raid, 5 = bg
+---@field expansionID ExpansionID
+---@field tagKey string # The key used to identify the dungeon in the addon
+---@field size number? # The size of the dungeon, only used for raids and battlegrounds
+---@field isHoliday boolean? # If the dungeon is a holiday event
+
+-- Required APIs. Exist in classic even though no Dungeon Finder.
+assert(GetLFGDungeonInfo, tocName .. " requires the API `GetLFGDungeonInfo` for parsing dungeon info")
+assert(C_LFGList.GetActivityInfoTable, tocName .. " requires the API `C_LFGList.GetActivityInfoTable` for parsing dungeon info")
+
+-- initialize here for now, this should be moved to a file thats always guarantied to load first.
+---@class AddonEnum
+addon.Enum = {} 
+
+
+---@enum DungeonTypeID # note that the actual value of the enum maybe be different depending on the client version.
+local DungeonType = {
+    Dungeon = 1,
+    Raid = 2,
+    None = 4,
+    Battleground = 5, -- in classic, 5 is used for BGs
+}
+
+---@enum ExpansionID
+local Expansions = {
+	Classic = 0,
+	BurningCrusade = 1,
+	Wrath = 2,
+	Cataclysm = 3,
+}
+
+local isSoD = C_Seasons and (C_Seasons.GetActiveSeason() == Enum.SeasonID.SeasonOfDiscovery)
+
+local debug = false
+local print = function(...) if debug then print(tocName, ...) end end
+
+-- hacky solution to manually tack on the dungeon size.
+-- this is only used for the classic era client. since its small enough to hardcode.
+-- `nil` is assumed to be 5
+local dungeonSizes = {
+    -- BGs
+    [53] = 10,  -- WSG
+    [55] = 15,  -- AB
+    [51] = 40,  -- AV
+    -- Dungeons
+    [31] = 10,  -- LBRS
+    [43] = 10,  -- UBRS
+    -- Raids
+    [41] = 20,  -- ZG
+    [160] = 20, -- AQ20
+    [47] = 40,  -- MC
+    [45] = 40,  -- Ony
+    [49] = 40,  -- BWL
+    [161] = 40, -- AQ40
+    [159] = 40, -- Naxx
+}
+
+-- manually associate keys in Tags.lua
+--see https://wago.tools/db2/LFGDungeons?build=1.15.2.54332
+local LFGDungeonIDs = {
+    ["RFC"] = 3,  -- Ragefire Chasm
+    ["WC"] = 1,  -- Wailing Caverns
+    ["DM"] = 5,  -- Deadmines
+    ["SFK"] = 7,  -- Shadowfang Keep
+    ["STK"] = 11, -- Stormwind Stockades
+    ["BFD"] = 9,  -- Blackfathom Deeps
+    ["GNO"] = 13,  -- Gnomeregan
+    ["RFK"] = 15,  -- Razorfen Kraul
+    ["SM2"] = 17,  -- Scarlet Monastery
+    ["RFD"] = 19,  -- Razorfen Downs
+    ["ULD"] = 21,  -- Uldaman
+    ["ZF"] = 23,  -- Zul'Farrak
+    ["MAR"] = 25,  -- Maraudon
+    ["ST"] = 27,  -- Sunken Temple
+    ["BRD"] = 29,  -- Blackrock Depths
+    ["DM2"] = 32,  -- Dire Maul [base]
+    ["DME"] = 33,  -- Dire Maul - East
+    ["DMN"] = 37,  -- Dire Maul - North
+    ["DMW"] = 35,  -- Dire Maul - West
+    ["STR"] = 39,  -- Stratholme
+    ["SCH"] = 2,  -- Scholomance
+    ["LBRS"] = 31,  -- Lower Blackrock Spire
+    ["UBRS"] = 43,  -- Upper Blackrock Spire
+    ["ZG"] = 41,  -- Zul'Gurub
+    ["ONY"] = 45,  -- Onyxia
+    ["MC"] = 47,  -- Molten Core
+    ["BWL"] = 49,  -- Blackwing Lair
+    ["WSG"] = 53,  -- Warsong Gulch
+    ["AB"] = 55,  -- Arathi Basin
+    ["AV"] = 51,  -- Alterac Valley
+}
+-- Note make sure the ID's dont overlap with LFGDungeonIDs
+--see https://wago.tools/db2/GroupFinderActivity?build=1.15.2.54332
+local LFGActivityIDs = {
+    ["AQ20"] = 842,  -- Ahn'Qiraj Ruins
+    ["AQ40"] = 843,  -- Ahn'Qiraj Temple
+    ["NAXX"] = 841,  -- Naxxramas
+    ["SMG"] = 805,  -- Scarlet Monastery - Graveyard
+    ["SML"] = 829,  -- Scarlet Monastery - Library
+    ["SMA"] = 827,  -- Scarlet Monastery - Armory
+    ["SMC"] = 828,  -- Scarlet Monastery - Cathedral
+}
+--see https://wago.tools/db2/GroupFinderCategory?build=1.15.2.54332
+local activityCategoryInfo  = {
+    [2] = { typeID = DungeonType.Dungeon },
+    [114] = { typeID = DungeonType.Raid },
+    [118] = { typeID = DungeonType.Battleground },
+}
+
+local idToDungeonKey = tInvert(LFGDungeonIDs)
+for key, id in pairs(LFGActivityIDs) do
+    idToDungeonKey[id] = key
+end
+
+--- Any info that needs to be overridden for a specific dungeon should be done here.
+local infoOverrides = {
+    -- BFD
+    BFD = isSoD and {
+        typeID = DungeonType.Raid,
+        minLevel = 25,
+        maxLevel = 40,
+        size = 10,
+    },
+    -- Gnomer
+    GNO = isSoD and {
+        typeID = DungeonType.Raid,
+        minLevel = 40,
+        maxLevel = 50,
+        size = 10,
+    },
+    -- Sunken Temple
+    ST = isSoD and {
+        typeID = DungeonType.Raid,
+        minLevel = 50,
+        maxLevel = 60,
+        size = 20,
+    },
+    -- UBRS is colloquially considered a dungeon. (in LFGDungeon table its a raid)
+    UBRS = { typeID = DungeonType.Dungeon },
+    
+    -- For the spoofed LFGDungeonID for "Dire Maul"
+    -- note: 32 is not a real entry in the LFGDungeon table for 1.15.xx.
+    DM2 = { 
+        name = GetRealZoneText(429),
+        minLevel = 54, 
+        maxLevel = 61, 
+        typeID = DungeonType.Dungeon
+    },
+
+    -- Since GetActivityInfoTable returns 0 for these values, set them manually.
+    AQ20 = { minLevel = 60, maxLevel = 60, typeID = DungeonType.Raid },
+    AQ40 = { minLevel = 60, maxLevel = 60, typeID = DungeonType.Raid },
+    NAXX = { minLevel = 60, maxLevel = 60, typeID = DungeonType.Raid },
+    SMG = { minLevel = 29, maxLevel = 37, typeID = DungeonType.Dungeon },
+    SML = { minLevel = 32, maxLevel = 38, typeID = DungeonType.Dungeon },
+    SMA = { minLevel = 36, maxLevel = 40, typeID = DungeonType.Dungeon },
+    SMC = { minLevel = 39, maxLevel = 45, typeID = DungeonType.Dungeon },
+}
+
+
+---@type {[DungeonID]: DungeonInfo}
+local dungeonInfoCache = {}
+---@type {[string]: DungeonInfo}
+local infoByTagKey = {}
+local numDungeons = 0
+do -- begin querying game client for localized dungeon info
+    local function cacheDungeonInfo(key, dungeonID)
+        local cached = {}
+        do
+            local name, typeID, _, minLevel, maxLevel = GetLFGDungeonInfo(dungeonID);
+            cached = {
+                name = name,
+                minLevel = minLevel,
+                maxLevel = maxLevel,
+                typeID = typeID,
+                tagKey = key,
+                expansionID = Expansions.Classic,
+            }
+        end
+
+        local overrides = infoOverrides[key]
+        if overrides then
+            for k, v in pairs(overrides) do
+                cached[k] = v
+            end
+        end
+
+        -- please add any missing data to info overrides
+        assert(cached.name, "Missing name for dungeonID: " .. dungeonID)
+        assert(cached.typeID, "Missing typeID for dungeonID: " .. dungeonID)
+        assert(cached.minLevel and cached.maxLevel, "Missing level range for dungeonID: " .. dungeonID)
+        
+        dungeonInfoCache[dungeonID] = cached
+        infoByTagKey[cached.tagKey] = cached
+        numDungeons = numDungeons + 1
+    end
+    local function cacheActivityInfo(key, activityID)
+        local cached = {}
+        local activityInfo = C_LFGList.GetActivityInfoTable(activityID)
+        local categoryInfo = activityCategoryInfo[activityInfo.categoryID]
+        cached = {
+            name = activityInfo.shortName or activityInfo.fullName,
+            minLevel = activityInfo.minLevel,
+            maxLevel = activityInfo.maxLevel,
+			typeID = categoryInfo.typeID,
+            tagKey = key,
+			expansionID = Expansions.Classic,
+        }
+        
+        local overrides = infoOverrides[key]
+        if overrides then
+            for k, v in pairs(overrides) do
+                cached[k] = v
+            end
+        end
+
+        -- please add any missing data to info overrides
+        assert(cached.name, "Missing name for activityID: " .. activityID)
+        assert(cached.typeID, "Missing typeID for activityID: " .. activityID)
+        assert(cached.minLevel and cached.maxLevel, "Missing level range for activityID: " .. activityID)
+
+        dungeonInfoCache[activityID] = cached
+        infoByTagKey[cached.tagKey] = cached
+        numDungeons = numDungeons + 1
+    end
+    for key, dungeonID in pairs(LFGDungeonIDs) do
+        cacheDungeonInfo(key, dungeonID)
+    end
+    for key, activityID in pairs(LFGActivityIDs) do
+        cacheActivityInfo(key, activityID)
+    end
+end
+
+---Returns info table for the specified dungeon key or `nil` if it doesn't exist.
+---@param dungeonKey string
+---@return (DungeonInfo|table<DungeonID, DungeonInfo>)? 
+function addon.GetDungeonInfo(dungeonKey, useRef)
+    if dungeonKey then
+        local info = infoByTagKey[dungeonKey]
+        if info then
+            return useRef and info or CopyTable(info)
+        end
+    end
+end
+
+---Optionally filter by expansionID and/or typeID
+---Sorted by min level, ties broken on min max level, then by dungeonID
+-- note: the new dungeons are sorted slightly differently,
+-- plan is to add  a custom sort index that users can-
+-- change in the config so that dungeons sorted to their preference.
+---@param expansionID ExpansionID?
+---@param typeID DungeonTypeID|DungeonTypeID[]?
+function addon.GetSortedDungeonKeys(expansionID, typeID)
+	local keys = {}
+	for dungeonID, info in pairs(dungeonInfoCache) do
+        local tagKey = idToDungeonKey[dungeonID]
+		if (not expansionID or info.expansionID == expansionID) 
+		and (not typeID -- only include set typeIDs
+			or (type(typeID) == "number" and info.typeID == typeID)
+			or (type(typeID) == "table" and tContains(typeID, info.typeID)))  
+        and (tagKey ~= "DM2" and tagKey ~= "SM2") -- not actually dungeons
+		then
+			tinsert(keys, tagKey)
+		end
+	end
+	table.sort(keys, function(keyA, keyB)
+		local infoA = infoByTagKey[keyA];
+        local infoB = infoByTagKey[keyB];
+        if infoA.typeID == infoB.typeID then
+            if infoA.minLevel == infoB.minLevel then
+                if infoA.maxLevel == infoB.maxLevel then
+                    if infoA.name == infoB.name then
+                        return keyA < keyB
+                    else return infoA.name < infoB.name end
+                else return infoA.maxLevel < infoB.maxLevel end
+            else return infoA.minLevel < infoB.minLevel end
+        else return infoA.typeID < infoB.typeID end
+	end)
+	return keys
+end
+
+local cachedLevelRanges
+function addon.GetDungeonLevelRanges()
+    if cachedLevelRanges then return cachedLevelRanges end
+    cachedLevelRanges = {}
+    for key, info in pairs(infoByTagKey) do
+        cachedLevelRanges[key] = {info.minLevel, info.maxLevel}
+    end
+    return cachedLevelRanges
+end
+
+addon.rawClassicDungeonInfo = infoByTagKey
+addon.Enum.DungeonType = DungeonType
+addon.Enum.Expansions = Expansions


### PR DESCRIPTION
These modules enable us to organize dungeon-related data according to the client being used.

Data is obtained using the `GetLFGDungeonInfo` and `GetActivityInfoTable` WoW API's and sourced `LFGDungeon` and `GroupFinderActivity` Ids for the two clients. 
Any data that either, cannot be obtained using the mentioned APIs, or needs modification from what is provided by the game API can be added in the `infoOverrides` table.

You can find the modules in the `/LFGBulletinBoard/dungeons/` directory. There are `cata.lua` and `classic.lua` files for the "Cataclysm Classic" and "Classic Era" clients, respectively.
  - [classic era](https://github.com/Vysci/LFG-Bulletin-Board/pull/236/commits/82f920fab1ddc8312b3d5091aedb9307db56268d)
  - [cataclysm](https://github.com/Vysci/LFG-Bulletin-Board/pull/236/commits/beb2ba4e543afc0ff48783f3c0bcc0c1d95982b4)

While the API for these modules should maintain some consistency (ie take same args and return same values), their internal implementations can differ. Refer to functions such as `GetDungeonInfo`, `GetSortedDungeonKeys`, and `GetDungeonLevelRanges` within the modules. 

Interfaces can be modified or added as needed, but ensure changes are reflected in both modules.

This PR comes along with some hotfixes needed to prevent cata clients from erroring but does no implement the added modules for generating the cata data yet. 