### PR TITLE
rework: Filter config panels hooked to new data modules

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -639,39 +639,14 @@ local function mergeTables(...)
 	return resulting
 end
 
--- Generated in /data/dungeons/
+-- Generated in `/dungeons/{version}.lua` files
+local classicDungeonLevels = GBB.GetDungeonLevelRanges(GBB.Enum.Expansions.Classic)
 
-local postTbcDungeonLevels = {
-	["RFC"] = 	{13,20}, ["DM"] = 	{16,24}, ["WC"] = 	{16,24}, ["SFK"] = 	{17,25}, ["STK"] = 	{21,29}, ["BFD"] = 	{20,28},
-	["GNO"] = 	{24,40}, ["RFK"] = 	{23,31}, ["SMG"] = 	{28,34}, ["SML"] = 	{30,38}, ["SMA"] = 	{32,42}, ["SMC"] = 	{35,44},
-	["RFD"] = 	{33,41}, ["ULD"] = 	{36,44}, ["ZF"] = 	{42,50}, ["MAR"] = 	{40,52}, ["ST"] = 	{45,54}, ["BRD"] = 	{48,60},
-	["LBRS"] = 	{54,60}, ["DME"] = 	{54,61}, ["DMN"] = 	{54,61}, ["DMW"] = 	{54,61}, ["STR"] = 	{56,61}, ["SCH"] = 	{56,61},
-	["UBRS"] = 	{53,61}, ["MC"] = 	{60,60}, ["ZG"] = 	{60,60}, ["AQ20"]= 	{60,60}, ["BWL"] = {60,60},
-	["AQ40"] = 	{60,60}, ["NAX"] = 	{60,60},
-	["MISC"] =  {0,100}, ["TRAVEL"]={0,100}, ["INCUR"]={0,100},
-	["DEBUG"] = {0,100}, ["BAD"] =	{0,100}, ["TRADE"]=	{0,100}, ["SM2"] =  {28,42}, ["DM2"] =	{58,60}, ["DEADMINES"]={16,24},
-}
+local tbcDungeonLevels = GBB.GetDungeonLevelRanges(GBB.Enum.Expansions.BurningCrusade)
 
-local tbcDungeonLevels = {
-	["RAMPS"] =  {60,62}, 	["BF"] = 	 {61,63},     ["SP"] = 	 {62,64},    ["UB"] = 	 {63,65},     ["MT"] = 	 {64,66},     ["CRYPTS"] = {65,67},
-	["SETH"] =   {67,69},  	["OHB"] = 	 {66,68},     ["MECH"] =   {69,70},    ["BM"] =      {69,70},    ["MGT"] =	 {70,70},    ["SH"] =	 {70,70},
-	["BOT"] =    {70,70},    ["SL"] = 	 {70,70},    ["SV"] =     {70,70},   ["ARC"] = 	 {70,70},    ["KARA"] = 	 {70,70},    ["GL"] = 	 {70,70},
-	["MAG"] =    {70,70},    ["SSC"] =    {70,70}, 	["EYE"] =    {70,70},   ["ZA"] = 	 {70,70},    ["HYJAL"] =  {70,70}, 	["BT"] =     {70,70},
-	["SWP"] =    {70,70},
-}
+local pvpLevels = GBB.GetDungeonLevelRanges(nil, GBB.Enum.DungeonType.Battleground)
 
-local pvpLevels = {
-	["WSG"] = 	{10,70}, ["AB"] = 	{20,70}, ["AV"] = 	{51,70},   ["WG"] = {80,80}, ["SOTA"] = {80,80},  ["EOTS"] =   {15,70},   ["ARENA"] = {70,80},
-	["BLOOD"] = {0,100},
-}
-
-local wotlkDungeonLevels = {
-	["UK"] =    {68,80},    ["NEX"] =    {69,80},    ["AZN"] =    {70,80},    ["ANK"] =    {71,80},    ["DTK"] =    {72,80},    ["VH"] =    {73,80},
-	["GD"] =    {74,80},    ["HOS"] =    {75,80},    ["HOL"] =    {76,80},    ["COS"] =    {78,80},    ["OCC"] =    {77,80},    ["UP"] =    {77,80},
-	["FOS"] =    {80,80},   ["POS"] =    {80,80},    ["HOR"] =    {80,80},    ["CHAMP"] =  {78,80},    ["OS"] =    {80,80},    ["VOA"] =    {80,80},
-	["EOE"] =    {80,80},   ["ULDAR"] =  {80,80},    ["TOTC"] =     {80,80},    ["RS"] =     {80,80},    ["ICC"] =    {80,80},    ["ONY"] =    {80,80},
-	["NAXX"] =   {80,80},   ["BREW"] = {65,70},      ["HOLLOW"] = {65,70},
-}
+local wotlkDungeonLevels = GBB.GetDungeonLevelRanges(GBB.Enum.Expansions.WrathOfTheLichKing)
 
 local wotlkDungeonNames = GBB.GetSortedDungeonKeys(
 	GBB.Enum.Expansions.Wrath,
@@ -824,16 +799,11 @@ function GBB.GetDungeonSort()
 	return dungeonSort
 end
 
-local function DetermineVanillDungeonRange()
-	return postTbcDungeonLevels
-end
-
-GBB.dungeonLevel = mergeTables(DetermineVanillDungeonRange(), tbcDungeonLevels, wotlkDungeonLevels, pvpLevels)
-
 if isClassicEra then
-	-- includes valid dungeons/raids/bgs
-	local dungeonLevels = GBB.GetDungeonLevelRanges()
-	-- needed because Option.lua hardcodes a checkbox for "DEADMINES"
-	dungeonLevels["DEADMINES"] = dungeonLevels["DM"]
-	GBB.dungeonLevel = mergeTables(dungeonLevels, miscCatergoriesLevels)
+	GBB.dungeonLevel = mergeTables(classicDungeonLevels, miscCatergoriesLevels)
+else
+	GBB.dungeonLevel = mergeTables(classicDungeonLevels, tbcDungeonLevels, wotlkDungeonLevels, pvpLevels, miscCatergoriesLevels)
 end
+
+-- needed because Option.lua hardcodes a checkbox for "DEADMINES"
+GBB.dungeonLevel["DEADMINES"] = GBB.dungeonLevel["DM"]

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -5,6 +5,8 @@ local ChannelIDs
 local ChkBox_FilterDungeon
 local TbcChkBox_FilterDungeon
 local isClassicEra = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local isCata = WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC
+
 --Options
 -------------------------------------------------------------------------------------
 
@@ -245,25 +247,46 @@ function GBB.OptionsInit ()
 	-- a global framexml string that's pre translated by blizzard called RESET_POSITION
 	GBB.Options.AddButton(RESET_POSITION,GBB.ResetWindow)
 	GBB.Options.AddSpace()
-	
-	-- Second Panel for Wotlk Dungeons
+	----------------------------------------------------------
+	-- Pre Cataclysm Filters
+	----------------------------------------------------------
 	if not isClassicEra then
-
+		------------------------------
+		--- Wrath Filters
+		------------------------------
 		GBB.Options.AddPanel(GBB.L["WotlkPanelFilter"])
-		GBB.Options.AddCategory(GBB.L["HeaderDungeon"])
-		GBB.Options.Indent(10)
-	
 		WotlkChkBox_FilterDungeon={}
-			
-		for index=GBB.WOTLKDUNGEONSTART,GBB.WOTLKDUNGEONBREAK do
-			WotlkChkBox_FilterDungeon[index]=CheckBoxFilter(GBB.dungeonSort[index],false)
+		local wrathDungeons = GBB.GetSortedDungeonKeys(
+			GBB.Enum.Expansions.Wrath, GBB.Enum.DungeonType.Dungeon
+		);
+		local wrathRaids = GBB.GetSortedDungeonKeys(
+			GBB.Enum.Expansions.Wrath, GBB.Enum.DungeonType.Raid
+		);
+		local wrathBgs = GBB.GetSortedDungeonKeys(
+			-- hack: for now use cata. Bg keys only exists for the latest expansion
+			GBB.Enum.Expansions.Cataclysm, GBB.Enum.DungeonType.Battleground
+		);
+		
+		-- Dungeons 		
+		GBB.Options.AddCategory(DUNGEONS)
+		GBB.Options.Indent(10)
+		for _, key in pairs(wrathDungeons) do
+			tinsert(WotlkChkBox_FilterDungeon, CheckBoxFilter(key, false))
+		end		
+		-- Raids
+		GBB.Options.Indent(-10)
+		GBB.Options.AddCategory(RAIDS)
+		GBB.Options.Indent(10)
+		for _, key in pairs(wrathRaids) do
+			tinsert(WotlkChkBox_FilterDungeon, CheckBoxFilter(key, false))
 		end
-	
+		-- Battlegrounds
 		GBB.Options.SetRightSide()
-		--GBB.Options.AddCategory("")
-		GBB.Options.Indent(10)	
-		for index=GBB.WOTLKDUNGEONBREAK+1,GBB.WOTLKMAXDUNGEON do
-			WotlkChkBox_FilterDungeon[index]=CheckBoxFilter(GBB.dungeonSort[index],false)
+		GBB.Options.Indent(-10)
+		GBB.Options.AddCategory(BATTLEGROUNDS)
+		GBB.Options.Indent(10)
+		for _, key in pairs(wrathBgs) do
+			tinsert(WotlkChkBox_FilterDungeon, CheckBoxFilter(key, false))
 		end
 		--GBB.Options.AddSpace()
 		CheckBoxChar("FilterLevel",false)
@@ -272,22 +295,19 @@ function GBB.OptionsInit ()
 		CheckBoxChar("NormalOnly", false)
 	
 		--GBB.Options.AddSpace()
-	
+		local numCheckBoxes = #WotlkChkBox_FilterDungeon
 		GBB.Options.InLine()
 		GBB.Options.AddButton(GBB.L["BtnSelectAll"],function()
-			DoSelectFilter(true, WotlkChkBox_FilterDungeon, GBB.WOTLKDUNGEONSTART, GBB.WOTLKMAXDUNGEON) -- Doing -2 to not select trade and misc
+			DoSelectFilter(true, WotlkChkBox_FilterDungeon, 1, numCheckBoxes)
 		end)
 		GBB.Options.AddButton(GBB.L["BtnUnselectAll"],function()
-			DoSelectFilter(false, WotlkChkBox_FilterDungeon, GBB.WOTLKDUNGEONSTART, GBB.WOTLKMAXDUNGEON)
+			DoSelectFilter(false, WotlkChkBox_FilterDungeon,1, numCheckBoxes)
 		end)
 	
 		GBB.Options.AddDrop(GBB.DB,"InviteRole", "DPS", {"DPS", "Tank", "Healer"})
 		GBB.Options.EndInLine()
 		GBB.Options.Indent(-10)
-		for index=GBB.ENDINGDUNGEONSTART,GBB.ENDINGDUNGEONEND do
-			WotlkChkBox_FilterDungeon[index]=CheckBoxFilter(GBB.dungeonSort[index],true)
-			SetChatOption()
-		end
+		SetChatOption()
 
 			-- Third Panel for TBC Dungeons
 		GBB.Options.AddPanel(GBB.L["TBCPanelFilter"])

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -288,7 +288,13 @@ function GBB.OptionsInit ()
 		for _, key in pairs(wrathBgs) do
 			tinsert(WotlkChkBox_FilterDungeon, CheckBoxFilter(key, false))
 		end
-		
+		-- Misc Categories
+		GBB.Options.Indent(-10)
+		GBB.Options.AddCategory(OTHER)
+		GBB.Options.Indent(10)
+		for _, key in pairs(GBB.Misc) do
+			tinsert(WotlkChkBox_FilterDungeon, CheckBoxFilter(key, false))
+		end
 		-- filter specific options
 		CheckBoxChar("FilterLevel",false)
 		CheckBoxChar("DontFilterOwn",false)
@@ -387,33 +393,32 @@ function GBB.OptionsInit ()
 		maxDungeonIdx = maxDungeonIdx + 1
 	end
 	
-	-- Battlegrounds & PVP
-	GBB.Options.AddCategory(BATTLEGROUNDS)
-	local classicBgKeys = GBB.GetSortedDungeonKeys(
-		GBB.Enum.Expansions.Classic, GBB.Enum.DungeonType.Battleground
-	);
-	-- hack: add `BLOOD` for SoD
-	if C_Seasons and (C_Seasons.GetActiveSeason() == Enum.SeasonID.SeasonOfDiscovery) then
-		table.insert(classicBgKeys, "BLOOD")
-	end
-	for _, key in pairs(classicBgKeys) do
-		ChkBox_FilterDungeon[maxDungeonIdx]=CheckBoxFilter(key, true)
-		boxWidths:add(ChkBox_FilterDungeon[maxDungeonIdx])
-		maxDungeonIdx = maxDungeonIdx + 1
-	end
-
-	-- Misc Categories
-	GBB.Options.AddCategory(OTHER)
-	for _, key in pairs(GBB.Misc) do
-		ChkBox_FilterDungeon[maxDungeonIdx]=CheckBoxFilter(key, true)
-		maxDungeonIdx = maxDungeonIdx + 1
-	end
-
-	-- filter specific options
-	CheckBoxChar("FilterLevel",false)
-	CheckBoxChar("DontFilterOwn",false)
+	if isClassicEra then -- dont redraw these when not in classic era
+		-- Battlegrounds & PVP
+		GBB.Options.AddCategory(BATTLEGROUNDS)
+		local classicBgKeys = GBB.GetSortedDungeonKeys(
+			GBB.Enum.Expansions.Classic, GBB.Enum.DungeonType.Battleground
+		);
+		-- hack: add `BLOOD` for SoD
+		if C_Seasons and (C_Seasons.GetActiveSeason() == Enum.SeasonID.SeasonOfDiscovery) then
+			table.insert(classicBgKeys, "BLOOD")
+		end
+		for _, key in pairs(classicBgKeys) do
+			ChkBox_FilterDungeon[maxDungeonIdx]=CheckBoxFilter(key, true)
+			boxWidths:add(ChkBox_FilterDungeon[maxDungeonIdx])
+			maxDungeonIdx = maxDungeonIdx + 1
+		end
 	
-	if not isClassicEra then
+		-- Misc Categories
+		GBB.Options.AddCategory(OTHER)
+		for _, key in pairs(GBB.Misc) do
+			ChkBox_FilterDungeon[maxDungeonIdx]=CheckBoxFilter(key, true)
+			maxDungeonIdx = maxDungeonIdx + 1
+		end
+
+		-- filter specific options
+		CheckBoxChar("FilterLevel",false)
+		CheckBoxChar("DontFilterOwn",false)
 		CheckBoxChar("HeroicOnly", false)
 		CheckBoxChar("NormalOnly", false)
 	end

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -262,7 +262,7 @@ function GBB.OptionsInit ()
 		local wrathRaids = GBB.GetSortedDungeonKeys(
 			GBB.Enum.Expansions.Wrath, GBB.Enum.DungeonType.Raid
 		);
-		local wrathBgs = GBB.GetSortedDungeonKeys(
+		local wrathBgs = GBB.GetSortedDungeonKeys( -- should be empty (if passing wotlk as expansion)
 			-- hack: for now use cata. Bg keys only exists for the latest expansion
 			GBB.Enum.Expansions.Cataclysm, GBB.Enum.DungeonType.Battleground
 		);
@@ -288,20 +288,21 @@ function GBB.OptionsInit ()
 		for _, key in pairs(wrathBgs) do
 			tinsert(WotlkChkBox_FilterDungeon, CheckBoxFilter(key, false))
 		end
-		--GBB.Options.AddSpace()
+		
+		-- filter specific options
 		CheckBoxChar("FilterLevel",false)
 		CheckBoxChar("DontFilterOwn",false)
 		CheckBoxChar("HeroicOnly", false)
 		CheckBoxChar("NormalOnly", false)
 	
 		--GBB.Options.AddSpace()
-		local numCheckBoxes = #WotlkChkBox_FilterDungeon
+		local xpacFilterCount = #WotlkChkBox_FilterDungeon
 		GBB.Options.InLine()
 		GBB.Options.AddButton(GBB.L["BtnSelectAll"],function()
-			DoSelectFilter(true, WotlkChkBox_FilterDungeon, 1, numCheckBoxes)
+			DoSelectFilter(true, WotlkChkBox_FilterDungeon, 1, xpacFilterCount)
 		end)
 		GBB.Options.AddButton(GBB.L["BtnUnselectAll"],function()
-			DoSelectFilter(false, WotlkChkBox_FilterDungeon,1, numCheckBoxes)
+			DoSelectFilter(false, WotlkChkBox_FilterDungeon,1, xpacFilterCount)
 		end)
 	
 		GBB.Options.AddDrop(GBB.DB,"InviteRole", "DPS", {"DPS", "Tank", "Healer"})
@@ -309,30 +310,37 @@ function GBB.OptionsInit ()
 		GBB.Options.Indent(-10)
 		SetChatOption()
 
-			-- Third Panel for TBC Dungeons
+		------------------------------
+		--- TBC Filters
+		------------------------------
 		GBB.Options.AddPanel(GBB.L["TBCPanelFilter"])
-		GBB.Options.AddCategory(GBB.L["HeaderDungeon"])
-		GBB.Options.Indent(10)
-
 		TbcChkBox_FilterDungeon={}
-			
-		for index=GBB.TBCDUNGEONSTART,GBB.TBCDUNGEONBREAK do
-			TbcChkBox_FilterDungeon[index]=CheckBoxFilter(GBB.dungeonSort[index],false)
+		local tbcDungeons = GBB.GetSortedDungeonKeys(
+			GBB.Enum.Expansions.BurningCrusade, GBB.Enum.DungeonType.Dungeon
+		);
+		local tbcRaids = GBB.GetSortedDungeonKeys(
+			GBB.Enum.Expansions.BurningCrusade, GBB.Enum.DungeonType.Raid
+		);
+		-- note: all bgs are included as part of latest xpac filters
+		
+		GBB.Options.AddCategory(DUNGEONS)
+		GBB.Options.Indent(10)
+		for _, key in pairs(tbcDungeons) do
+			tinsert(TbcChkBox_FilterDungeon, CheckBoxFilter(key, false))
 		end
-
 		GBB.Options.SetRightSide()
-		--GBB.Options.AddCategory("")
+		GBB.Options.AddCategory(RAIDS)
 		GBB.Options.Indent(10)	
-		for index=GBB.TBCDUNGEONBREAK+1,GBB.TBCMAXDUNGEON do
-			TbcChkBox_FilterDungeon[index]=CheckBoxFilter(GBB.dungeonSort[index],false)
+		for _, key in pairs(tbcRaids) do
+			tinsert(TbcChkBox_FilterDungeon, CheckBoxFilter(key, false))
 		end
-
+		xpacFilterCount = #TbcChkBox_FilterDungeon
 		GBB.Options.InLine()
 		GBB.Options.AddButton(GBB.L["BtnSelectAll"],function()
-			DoSelectFilter(true, TbcChkBox_FilterDungeon, GBB.TBCDUNGEONSTART, GBB.TBCMAXDUNGEON)
+			DoSelectFilter(true, TbcChkBox_FilterDungeon, 1, xpacFilterCount)
 		end)
 		GBB.Options.AddButton(GBB.L["BtnUnselectAll"],function()
-			DoSelectFilter(false, TbcChkBox_FilterDungeon, GBB.TBCDUNGEONSTART, GBB.TBCMAXDUNGEON)
+			DoSelectFilter(false, TbcChkBox_FilterDungeon, 1, xpacFilterCount)
 		end)
 		GBB.Options.EndInLine()
 	end

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -585,34 +585,25 @@ GBB.dungeonSecondTags = {
 }
 
 -- Remove any unused dungeon tags based on game version
-if isClassicEra then
-	-- Get available dungeon tag keys up to current expansion
-	-- this includes raids/bgs/arenas/dungeons
-	local validDungeonKeys = GBB.GetSortedDungeonKeys()
-	local validGameVersionKeys = {}
-	for _, key in ipairs(validDungeonKeys) do
-		validGameVersionKeys[key] = true
-	end
-	for _, key in ipairs(GBB.Misc) do	
-		validGameVersionKeys[key] = true
-	end
-	-- iterate over all locales and `nil` out any entries for dungeons not valid for vanilla
-	for locale, dungeonTags in pairs(GBB.dungeonTagsLoc) do
-		for dungeonKey, _ in pairs(dungeonTags) do
-			if not (validGameVersionKeys[dungeonKey] 
-				or GBB.dungeonSecondTags[dungeonKey])
-			then
-				GBB.dungeonTagsLoc[locale][dungeonKey] = nil
-			end
-		end
-	end
-else
-	-- remove Bloodmoon and Incursions
-	for locale, dungeonTags in pairs(GBB.dungeonTagsLoc) do
-		for dungeonKey, _ in pairs(dungeonTags) do
-			if dungeonKey == "BLOOD" or dungeonKey == "INCUR" then
-				GBB.dungeonTagsLoc[locale][dungeonKey] = nil
-			end
+
+-- Passing no specific dungeonType or ExpansionID will yeild all available.
+-- This includes raids/bgs/arenas/dungeons from classic up to current expansion
+local validDungeonKeys = GBB.GetSortedDungeonKeys()
+local validGameVersionKeys = {}
+for _, key in ipairs(validDungeonKeys) do
+	validGameVersionKeys[key] = true
+end
+-- manually add MISC entries to validGameVersionKeys, this is kinda hacky atm.
+for _, key in ipairs(GBB.Misc) do	
+	validGameVersionKeys[key] = true
+end
+-- iterate over all locales and `nil` out any entries for dungeons not in current client
+for locale, dungeonTags in pairs(GBB.dungeonTagsLoc) do
+	for dungeonKey, _ in pairs(dungeonTags) do
+		if not (validGameVersionKeys[dungeonKey] 
+			or GBB.dungeonSecondTags[dungeonKey])
+		then
+			GBB.dungeonTagsLoc[locale][dungeonKey] = nil
 		end
 	end
 end

--- a/LFGBulletinBoard/dungeons/cata.lua
+++ b/LFGBulletinBoard/dungeons/cata.lua
@@ -422,6 +422,7 @@ end
 --Optionally filter by expansionID and/or typeID
 ---@param expansionID ExpansionID?
 ---@param typeID DungeonTypeID|DungeonTypeID[]?
+---@return string[]
 function addon.GetSortedDungeonKeys(expansionID, typeID)
 	local keys = {}
 	for tagKey, info in pairs(infoByTagKey) do


### PR DESCRIPTION
These commits connect a couple of components up to the new data modules introduced in #236.

Specifically:
  -  `GGB.dungeonLevel` [6051d20](https://github.com/Vysci/LFG-Bulletin-Board/pull/237/commits/6051d20d837a11c9ddda758dacd47fda006a359e)
  - `..DungeonName` tables for all expansions. [faa00a5](https://github.com/Vysci/LFG-Bulletin-Board/pull/237/commits/faa00a53ff8cc0f79a6341681ccabd0a879953fc)
    - These tables had a list of pre sorted dungeon keys. Now generated using the `GetSortedDungeonKeys` functions in the new modules.
  - The "Filters" configuration panels for all expansions. [1b41941](https://github.com/Vysci/LFG-Bulletin-Board/pull/237/commits/1b4194120ad0142d468197f4d9cde01d8aacf876) - [c1db615](https://github.com/Vysci/LFG-Bulletin-Board/pull/237/commits/c1db615777a3eaf7c7a8d5d33e020bb0371714f0)
    - These now use the aforementioned `GetSortedDungeonKeys` to generate all the valid keys per expansion, based on the dungeon type (raid/dungeon/battleground)
    - New module allows for easy separation of dungeon types to make setting easier to navigate for users.
    - ![WowClassic_cXIJbdDzvY.gif](https://i.imgur.com/wvSRY2j.gif)
    
  **Note** - These changes do not add the cataclysm filters panel, they are added in later commits which will be PR'ed after this.