### PR TITLE
feature: preliminary settings support for Cataclysm dungeons

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -648,11 +648,10 @@ end
 -- Generated in `/dungeons/{version}.lua` files
 local classicDungeonLevels = GBB.GetDungeonLevelRanges(GBB.Enum.Expansions.Classic)
 
-local tbcDungeonLevels = GBB.GetDungeonLevelRanges(GBB.Enum.Expansions.BurningCrusade)
-
-local pvpLevels = GBB.GetDungeonLevelRanges(nil, GBB.Enum.DungeonType.Battleground)
-
-local wotlkDungeonLevels = GBB.GetDungeonLevelRanges(GBB.Enum.Expansions.WrathOfTheLichKing)
+local cataDungeonKeys = GBB.GetSortedDungeonKeys(
+	GBB.Enum.Expansions.Cataclysm,
+	{ GBB.Enum.DungeonType.Dungeon, GBB.Enum.DungeonType.Raid }
+);
 
 local wotlkDungeonNames = GBB.GetSortedDungeonKeys(
 	GBB.Enum.Expansions.Wrath,
@@ -690,7 +689,6 @@ local miscCatergoriesLevels = {
 	["DEBUG"] = {0,100}, ["BAD"] =	{0,100}, ["TRADE"]=	{0,100},
 	["BLOOD"] = {0,100}, ["NIL"] = {0,100}
 }
-
 
 -- Needed because Lua sucks, Blizzard switch to Python please
 -- Takes in a list of dungeon lists, it will then concatenate the lists into a single list
@@ -746,11 +744,13 @@ GBB.Misc = {"MISC", "TRADE", "TRAVEL", (isSoD and "INCUR" or nil)}
 -- in FixFilters of Options.lua
 GBB.Seasonal = {
     ["BREW"] = { startDate = "09/20", endDate = "10/06"},
-	["HOLLOW"] = { startDate = "10/18", endDate = "11/01"}
+	["HOLLOW"] = { startDate = "10/18", endDate = "11/01"},
+	["LOVE"] = {startDate = "02/03", endDate = "02/17"},
+	["SUMMER"] = {startDate = "06/21", endDate = "07/05"},
 }
 
--- clear unused dungeons in classic to not generate options/checkboxes
--- with the new data pipeline api these tables should already empty anyways when in classic client
+-- clear unused dungeons in classic to not generate options/checkboxes with the-
+-- new data pipeline api these tables should already empty anyways when in classic client
 if isClassicEra then
 	tbcDungeonNames = {}
 	wotlkDungeonNames = {}
@@ -762,17 +762,21 @@ function GBB.GetDungeonSort()
 	-- when i add support for the newly added holiday dungeons.
 	for eventName, eventData in pairs(GBB.Seasonal) do
         if GBB.Tool.InDateRange(eventData.startDate, eventData.endDate) then
-			table.insert(wotlkDungeonNames, 1, eventName)
+			table.insert(cataDungeonKeys, 1, eventName)
 		else
 			table.insert(debugNames, 1, eventName)
 		end
     end
 
-	local dungeonOrder = { GBB.VanillaDungeonKeys, tbcDungeonNames, wotlkDungeonNames, pvpNames, GBB.Misc, debugNames}
+	local dungeonOrder = { 
+		GBB.VanillaDungeonKeys, tbcDungeonNames, wotlkDungeonNames, cataDungeonKeys, 
+		pvpNames, GBB.Misc, debugNames
+	}
 
 	local vanillaDungeonSize = #GBB.VanillaDungeonKeys
 	local tbcDungeonSize = #tbcDungeonNames
 	local wotlkDungeonSize = #wotlkDungeonNames
+	local cataDungeonSize = #cataDungeonKeys
 	local debugSize = #debugNames
 
 	local tmp_dsort, concatenatedSize = ConcatenateLists(dungeonOrder)
@@ -782,8 +786,10 @@ function GBB.GetDungeonSort()
 	GBB.MAXDUNGEON = vanillaDungeonSize
 	GBB.TBCMAXDUNGEON = vanillaDungeonSize  + tbcDungeonSize
 	GBB.WOTLKDUNGEONSTART = GBB.TBCMAXDUNGEON + 1
-	GBB.WOTLKMAXDUNGEON = wotlkDungeonSize + GBB.TBCMAXDUNGEON
+	GBB.WOTLKMAXDUNGEON = wotlkDungeonSize + GBB.TBCMAXDUNGEON + cataDungeonSize
 	GBB.ENDINGDUNGEONSTART = GBB.WOTLKMAXDUNGEON + 1
+	
+	-- used in Options.lua for drawing dungeon editboxes for search patterns 
 	GBB.ENDINGDUNGEONEND = concatenatedSize - debugSize - 1
 
 	for dungeon,nb in pairs(tmp_dsort) do
@@ -798,9 +804,10 @@ function GBB.GetDungeonSort()
 	dungeonSort[dungeonSort["SM2"]] = "SM2"
 	dungeonSort[dungeonSort["DM2"]] = "DM2"
 
-	-- This is set to a high index with no reverse link because we dont ever want to show this in the list during `UpdateList()`
+	-- This is set to a high index with no reverse link because-
+	-- we dont ever want to show this in the list during `UpdateList()` (might not be relevant anymore)
 	-- Ideally the "DEADMINES" key should never make it to the `req.dungeon` field as it should be converted to either "DM" or "DM2"/"DMW"/"DME"/"DMN" in GBB.GetDungeon() 
-	dungeonSort["DEADMINES"] = 99
+	dungeonSort["DEADMINES"] = GBB.ENDINGDUNGEONEND + 20
 	
 	return dungeonSort
 end
@@ -808,7 +815,10 @@ end
 if isClassicEra then
 	GBB.dungeonLevel = mergeTables(classicDungeonLevels, miscCatergoriesLevels)
 else
-	GBB.dungeonLevel = mergeTables(classicDungeonLevels, tbcDungeonLevels, wotlkDungeonLevels, pvpLevels, miscCatergoriesLevels)
+	GBB.dungeonLevel = mergeTables(
+		GBB.GetDungeonLevelRanges(), -- all dungeon types, all expansions
+		miscCatergoriesLevels
+	)
 end
 
 -- needed because Option.lua hardcodes a checkbox for "DEADMINES"

--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -617,6 +617,12 @@ function GBB.GetDungeonNames()
 	end
 
 
+	-- use client generated names instead of english- 
+	-- as fallbacks for missing manual translations
+	local dungeonKeys = GBB.GetSortedDungeonKeys()
+	for _, key in ipairs(dungeonKeys) do
+		DefaultEnGB[key] = GBB.GetDungeonInfo(key).name or DefaultEnGB[key]
+	end
 	setmetatable(dungeonNames, {__index = DefaultEnGB})
 
 	dungeonNames["DEADMINES"]=dungeonNames["DM"]

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -637,8 +637,12 @@ function GBB.Init()
 		GroupBulletinBoardFrame_GroupFrame:Hide()
 	else
 		GBB.Tool.AddTab(GroupBulletinBoardFrame,GBB.L.TabRequest,GroupBulletinBoardFrame_ScrollFrame)
-		GBB.Tool.AddTab(GroupBulletinBoardFrame,GBB.L.TabLfg,GroupBulletinBoardFrame_LfgFrame)
-		GBB.Tool.AddTab(GroupBulletinBoardFrame,GBB.L.TabGroup,GroupBulletinBoardFrame_GroupFrame)
+		GBB.Tool.AddTab(GroupBulletinBoardFrame,GBB.L.TabLfg,GroupBulletinBoardFrame_LfgFrame);
+		(GroupBulletinBoardFrame.Tabs[2]--[[@as button]]):SetText(
+			WrapTextInColorCode(GroupBulletinBoardFrame.Tabs[2]:GetText(), "FF6D6D6D")
+		);
+		(GroupBulletinBoardFrame.Tabs[2]--[[@as button]]):EnableMouse(false);
+		-- GBB.Tool.AddTab(GroupBulletinBoardFrame,GBB.L.TabGroup,GroupBulletinBoardFrame_GroupFrame)
 	end
 	GBB.Tool.SelectTab(GroupBulletinBoardFrame,1)
 	if GBB.DB.EnableGroup then

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -31,7 +31,14 @@ local function CheckBoxChar (Var,Init)
 	return GBB.Options.AddCheckBox(GBB.DBChar,Var,Init,GBB.L["CboxChar"..Var])
 end
 local function CheckBoxFilter (Dungeon,Init)
-	return GBB.Options.AddCheckBox(GBB.DBChar,"FilterDungeon".. Dungeon,Init,GBB.dungeonNames[Dungeon].." "..GBB.LevelRange(Dungeon,true))
+	local dungeonName = (GBB.GetDungeonInfo(Dungeon, true) or {}).name
+	return GBB.Options.AddCheckBox(
+		GBB.DBChar, "FilterDungeon".. Dungeon, 
+		Init, 
+		((GBB.dungeonNames[Dungeon] 
+			or dungeonName or "ERROR"
+		).." "..GBB.LevelRange(Dungeon,true))
+	)
 end
 local function CreateEditBoxNumber (Var,Init,width,width2)
 	return GBB.Options.AddEditBox(GBB.DB,Var,Init,GBB.L["Edit"..Var],width,width2,true)
@@ -46,8 +53,15 @@ local function CreateEditBoxDungeon(Dungeon,Init,width,width2)
 		GBB.DB.Custom[Dungeon]=GBB.DB["Custom_"..Dungeon]
 		GBB.DB["Custom_"..Dungeon]=nil
 	end
-	if GBB.dungeonNames[Dungeon] then
-		GBB.Options.AddEditBox(GBB.DB.Custom, Dungeon, Init, GBB.dungeonNames[Dungeon].." "..GBB.LevelRange(Dungeon,true), width, width2, false,nil, GBB.Tool.Combine(GBB.dungeonTagsLoc["enGB"][Dungeon]))
+	local dungeonName = (GBB.GetDungeonInfo(Dungeon, true) or {}).name
+	if GBB.dungeonNames[Dungeon] or dungeonName then
+		GBB.Options.AddEditBox(GBB.DB.Custom, Dungeon, Init, 
+			((GBB.dungeonNames[Dungeon] or 
+				dungeonName).." "..GBB.LevelRange(Dungeon,true)
+			),
+			width, width2, false, nil, 
+			GBB.Tool.Combine(GBB.dungeonTagsLoc["enGB"][Dungeon])
+		)
 	else
 		local txt=""
 		if Dungeon=="Search" then

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -14,13 +14,12 @@ local PROJECT_EXPANSION_ID = {
 	[WOW_PROJECT_CATACLYSM_CLASSIC or 0] = GBB.Enum.Expansions.Cataclysm,
 }
 local EXPANSION_PROJECT_ID = tInvert(PROJECT_EXPANSION_ID)
+
 local EXPANSION_FILTER_NAME = {
-	[GBB.Enum.Expansions.Classic] = 
-		GBB.locales[GetLocale()]["PanelFilter"] or EXPANSION_NAME0,
-	[GBB.Enum.Expansions.BurningCrusade] = 
-		GBB.locales[GetLocale()]["TBCPanelFilter"] or EXPANSION_NAME1,
-	[GBB.Enum.Expansions.Wrath] = EXPANSION_NAME2,
-	[GBB.Enum.Expansions.Cataclysm] = EXPANSION_NAME3,
+	[GBB.Enum.Expansions.Classic] = SUBTITLE_FORMAT:format(FILTERS, EXPANSION_NAME0),
+	[GBB.Enum.Expansions.BurningCrusade] = SUBTITLE_FORMAT:format(FILTERS, EXPANSION_NAME1),
+	[GBB.Enum.Expansions.Wrath] = SUBTITLE_FORMAT:format(FILTERS, EXPANSION_NAME2),
+	[GBB.Enum.Expansions.Cataclysm] = SUBTITLE_FORMAT:format(FILTERS, EXPANSION_NAME3),
 }
 --Options
 -------------------------------------------------------------------------------------

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -19,8 +19,7 @@ local EXPANSION_FILTER_NAME = {
 		GBB.locales[GetLocale()]["PanelFilter"] or EXPANSION_NAME0,
 	[GBB.Enum.Expansions.BurningCrusade] = 
 		GBB.locales[GetLocale()]["TBCPanelFilter"] or EXPANSION_NAME1,
-	[GBB.Enum.Expansions.Wrath] = 
-		GBB.locales[GetLocale()]["WotlkPanelFilter"] or EXPANSION_NAME2,
+	[GBB.Enum.Expansions.Wrath] = EXPANSION_NAME2,
 	[GBB.Enum.Expansions.Cataclysm] = EXPANSION_NAME3,
 }
 --Options
@@ -159,11 +158,7 @@ end
 local function GenerateExpansionPanel(expansionID)
 	GBB.Options.AddPanel(EXPANSION_FILTER_NAME[expansionID], false, true)
 	
-	-- hack to show misc filters on wotlk panel
-	local WOW_PROJECT_ID = isCata and WOW_PROJECT_WRATH_CLASSIC or WOW_PROJECT_ID;
-	
 	local isCurrentXpac = expansionID == PROJECT_EXPANSION_ID[WOW_PROJECT_ID];
-	local xOffset = 0
 	local filters = {} ---@type CheckButton[]
 	local dungeons = GBB.GetSortedDungeonKeys(
 		expansionID, GBB.Enum.DungeonType.Dungeon
@@ -175,14 +170,6 @@ local function GenerateExpansionPanel(expansionID)
 		expansionID, GBB.Enum.DungeonType.Battleground
 	);
 	
-	-- hack to show bgs on wotlk panel atm
-	-- Bg keys only exists for the latest expansion
-	if expansionID == GBB.Enum.Expansions.Wrath then
-		bgs = GBB.GetSortedDungeonKeys(
-			GBB.Enum.Expansions.Cataclysm, GBB.Enum.DungeonType.Battleground
-		);
-	end
-
 	-- Dungeons 		
 	GBB.Options.AddCategory(DUNGEONS)
 	GBB.Options.Indent(10)
@@ -372,24 +359,19 @@ function GBB.OptionsInit ()
 	GBB.Options.AddButton(RESET_POSITION,GBB.ResetWindow)
 	GBB.Options.AddSpace()
 	----------------------------------------------------------
-	-- Pre Cataclysm Filters
+	-- Expansion specific filters
 	----------------------------------------------------------
-	if not isClassicEra then
-		------------------------------
+	if not isClassicEra then 
+		--- Cata Filters
+		GenerateExpansionPanel(GBB.Enum.Expansions.Cataclysm)
 		--- Wrath Filters
-		------------------------------
 		GenerateExpansionPanel(GBB.Enum.Expansions.Wrath)
-		------------------------------
 		--- TBC Filters
-		------------------------------
 		GenerateExpansionPanel(GBB.Enum.Expansions.BurningCrusade)
 	end
-	
-	----------------------------------------------------------
 	-- Vanilla Filters
-	----------------------------------------------------------
 	GenerateExpansionPanel(GBB.Enum.Expansions.Classic)
-	
+		
 	----------------------------------------------------------
 	-- Tags
 	----------------------------------------------------------

--- a/LFGBulletinBoard/changelog.txt
+++ b/LFGBulletinBoard/changelog.txt
@@ -1,6 +1,13 @@
 --[[
 
 Group Bulletin Board 	
+3.3alpha
+ - Tool request tab temporarily disabled until it can be fixed
+ - Search pattern support for cata dungeons (see Search Patterns config)
+ - missing localizations for dungeon names added. (includes ptBR)
+ - Updates to expansion filters in the config panel.
+ - cataclysm basic support (no search tags yet just ui) 
+ - fixes to duplicate request with realm names enabled
 
 3.24  
  - All credit goes to juemrami for all the fixes.

--- a/LFGBulletinBoard/dungeons/cata.lua
+++ b/LFGBulletinBoard/dungeons/cata.lua
@@ -31,22 +31,22 @@ local DungeonType = {
 -- These same keys are used for identifying the preset tags/keywords for each dungeon. If a tags Key is missing from this table, the tags will not be registered.
 -- modifications here should be reflected in the `Tags.lua` file and vice versa.
 local LFGDungeonIDs = {
-	NULL = 358,	-- 10v10 Rated Battleground (RBG)
+	RBG = 358,	-- 10v10 Rated Battleground (RBG)
 	AQ20 = 160,	-- Ahn'Qiraj Ruins
 	AQ40 = 161,	-- Ahn'Qiraj Temple
 	ANK = 218,	-- Ahn'kahet: The Old Kingdom
 	CRYPTS = 149,	-- Auchenai Crypts
 	AZN = 204,	-- Azjol-Nerub
-	NULL = 328,	-- Baradin Hold
+	BH = 328,	-- Baradin Hold
 	BT = 196,	-- Black Temple
 	BFD = 10,   -- Blackfathom Deeps
-	NULL = 303,	-- Blackrock Caverns
+	BRC = 303,	-- Blackrock Caverns
 	
 	-- These get put into "BRD"
 	NULL = 30,  -- Blackrock Depths - Detention Block
 	NULL = 276,	-- Blackrock Depths - Upper City
 	
-	NULL = 313,	-- Blackwing Descent
+	BWD = 313,	-- Blackwing Descent
 	BWL = 50,   -- Blackwing Lair
 	BF = 137,	-- Blood Furnace
 	DM = 6,     -- Deadmines
@@ -55,25 +55,25 @@ local LFGDungeonIDs = {
 	DME = 34,	-- Dire Maul - East (Renamed in Cata)
 	DMN = 38,	-- Dire Maul - North (Renamed in Cata)
 	DMW = 36,	-- Dire Maul - West (Renamed in Cata)
-	NULL = 447,	-- Dragon Soul
+	-- DS = 447,	-- Dragon Soul
 	DTK = 214,	-- Drak'Tharon Keep
-	NULL = 435,	-- End Time
-	NULL = 417,	-- Fall of Deathwing
-	NULL = 361,	-- Firelands
+	-- END_TIME = 435,	-- End Time
+	NULL = 417,	-- Fall of Deathwing (LFR)
+	-- FL = 361,	-- Firelands
 	GNO = 14,   -- Gnomeregan
-	NULL = 304,	-- Grim Batol
+	GB = 304,	-- Grim Batol
 	GL = 177,	-- Gruul's Lair
 	GD = 216,	-- Gundrak
 	HOL = 207,	-- Halls of Lightning
-	NULL = 305,	-- Halls of Origination
+	HOO = 305,	-- Halls of Origination
 	HOR = 255,	-- Halls of Reflection
 	HOS = 208,	-- Halls of Stone
 	RAMPS = 136,-- Hellfire Ramparts
-	NULL = 439,	-- Hour of Twilight
+	-- HOT = 439,	-- Hour of Twilight
 	HYJAL = 195,-- Hyjal Past
 	ICC = 279,	-- Icecrown Citadel
 	KARA = 175,	-- Karazhan
-	NULL = 312,	-- Lost City of the Tol'vir
+	TOLVIR = 312,	-- Lost City of the Tol'vir
 	LBRS = 32,  -- Lower Blackrock Spire
 	MGT = 198,	-- Magisters' Terrace
 	MAG = 176,	-- Magtheridon's Lair
@@ -118,7 +118,7 @@ local LFGDungeonIDs = {
 	ST = 28,    -- Sunken Temple
 	EYE = 193,	-- Tempest Keep (The Eye)
 	ARC = 174,	-- The Arcatraz
-	NULL = 315,	-- The Bastion of Twilight
+	BOT2 = 315,	-- The Bastion of Twilight
 	BOT = 173,	-- The Botanica
 	COS = 209,	-- The Culling of Stratholme
 	OHB = 170,	-- The Escape From Durnholde (Old Hillsbrad Foothills)
@@ -128,13 +128,13 @@ local LFGDungeonIDs = {
 	NEX = 225,	-- The Nexus
 	OS = 224,	-- The Obsidian Sanctum
 	OCC = 206,	-- The Oculus
-	NULL = 416,	-- The Siege of Wyrmrest Temple
+	NULL = 416,	-- The Siege of Wyrmrest Temple (LFR)
 	SV = 147,	-- The Steamvault
-	NULL = 307,	-- The Stonecore
+	TSC = 307,	-- The Stonecore
 	SWP = 199,	-- The Sunwell
-	NULL = 311,	-- The Vortex Pinnacle
-	NULL = 317,	-- Throne of the Four Winds
-	NULL = 302,	-- Throne of the Tides
+	VP = 311,	-- The Vortex Pinnacle
+	TOFW = 317,	-- Throne of the Four Winds
+	TOTT = 302,	-- Throne of the Tides
 	CHAMP = 245,-- Trial of the Champion
 	TOTC = {
 		246,	-- Trial of the Crusader
@@ -156,15 +156,15 @@ local LFGDungeonIDs = {
 
 	-- Seasonal
 	BREW = 287,	-- Coren Direbrew (Brewfest)
-	NULL = 288,	-- The Crown Chemical Co. (Love is in the Air)
-	NULL = 286,	-- The Frost Lord Ahune (Midsummer)
+	LOVE = 288,	-- The Crown Chemical Co. (Love is in the Air)
+	SUMMER = 286,	-- The Frost Lord Ahune (Midsummer)
 	HOLLOW = 285,	-- The Headless Horseman (Hallow's End)
 
-	-- Cata prepatch bosses
-	EARTH_PORTAL = 297,	-- Crown Princess Theradras
-	FIRE_PORTAL = 296,	-- Grand Ambassador Flamelash
-	WATER_PORTAL = 298,	-- Kai'ju Gahz'rilla
-	AIR_PORTAL = 299,	-- Prince Sarsarun
+	-- Cata prepatch bosses (unused for cata rerelease)
+	-- EARTH_PORTAL = 297,	-- Crown Princess Theradras
+	-- FIRE_PORTAL = 296,	-- Grand Ambassador Flamelash
+	-- WATER_PORTAL = 298,	-- Kai'ju Gahz'rilla
+	-- AIR_PORTAL = 299,	-- Prince Sarsarun
 }
 local dungeonIDToKey = {}
 for key, dungeonID in pairs(LFGDungeonIDs) do
@@ -302,7 +302,7 @@ local infoOverrides = {
 	-- DMN = { minLevel = 42, maxLevel = 52 },
 	-- The pvp dungeons arent in th LFGDungeons table in the cata client atm. (except for RBG)
 	-- and the GetActivityInfoTable API is returning `0` for min/max level so we'll just hardcode it here.
-	ARENA = { minLevel = 10, maxLevel = effectiveMaxLevel },
+	ARENA = { minLevel = effectiveMaxLevel, maxLevel = effectiveMaxLevel },
 	WSG = { minLevel = 10, maxLevel = effectiveMaxLevel },
 	AB = { minLevel = 10, maxLevel = effectiveMaxLevel },
 	EOTS = { minLevel = 35, maxLevel = effectiveMaxLevel },

--- a/LFGBulletinBoard/dungeons/cata.lua
+++ b/LFGBulletinBoard/dungeons/cata.lua
@@ -166,6 +166,14 @@ local LFGDungeonIDs = {
 	-- WATER_PORTAL = 298,	-- Kai'ju Gahz'rilla
 	-- AIR_PORTAL = 299,	-- Prince Sarsarun
 }
+
+-- hack: add cata versions of sfk and deadmines at max level
+local isCataLevel = UnitLevel("player") >= 84
+if isCataLevel then
+	LFGDungeonIDs.DM = 326
+	LFGDungeonIDs.SFK = 327
+end
+
 local dungeonIDToKey = {}
 for key, dungeonID in pairs(LFGDungeonIDs) do
     if type(dungeonID) == "table" then
@@ -311,7 +319,14 @@ local infoOverrides = {
 	WG = { minLevel = 71, maxLevel = effectiveMaxLevel },
 	RBG = { typeID = DungeonType.Battleground }, -- GetLFGDungeonInfo considers it a raid for some reason.
 	-- TB = { minLevel = effectiveMaxLevel, maxLevel = effectiveMaxLevel },
-
+	DM = isCataLevel and {
+		name = DUNGEON_NAME_WITH_DIFFICULTY:format(
+				DUNGEON_FLOOR_THEDEADMINES1, DUNGEON_DIFFICULTY2),
+		} or nil,
+	SFK = isCataLevel and { 
+		name = DUNGEON_NAME_WITH_DIFFICULTY:format(
+			GetRealZoneText(33), DUNGEON_DIFFICULTY2)
+	} or nil,
 }
 
 ---@type {[DungeonID]: DungeonInfo}


### PR DESCRIPTION
Proceeds #237

These commits finish basic settings support for Cataclysm dungeons.
Additionally, disables the "Request List" tab in cataclysm clients while its made functional (todo)

**Note** - These changes do not add any preset tags for the new dungeons but adds the edit boxes in the config panels so that users can add their own patterns. Default English tags for Cataclysm dungeons are included in a future PR.

**images**
![filterboxes](https://i.imgur.com/og9SUVr.png)
![editboxes](https://i.imgur.com/qBNAAKI.png)


