### PR TITLE
feature: add UI indicators for moused-over entries and headers

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -731,9 +731,10 @@ local function Event_CHAT_MSG_SYSTEM(arg1)
 			local txt
 			
 			if class and class~="" then 
-				txt="|Hplayer:"..name.."|h"..GBB.Tool.IconClass[class]..
-				"|c"..GBB.Tool.ClassColor[class].colorStr ..
-				name.."|r"..symbol.."|h"
+				txt="|Hplayer:"..name.."|h"
+					..(GBB.Tool.GetClassIcon(req.class) or "")
+					.."|c"..GBB.Tool.ClassColor[class].colorStr .. name.."|r"
+					..symbol.."|h";
 			else
 				txt="|Hplayer:"..name.."|h"..name..symbol.."|h"
 			end

--- a/LFGBulletinBoard/GroupList.lua
+++ b/LFGBulletinBoard/GroupList.lua
@@ -64,7 +64,7 @@ function GBB.AddGroupList(entry)
 	end
 	GroupBulletinBoardFrame_GroupFrame:AddMessage(
 		"|Hplayer:".. entry.name .."|h"..
-		GBB.Tool.IconClass[entry.class]..
+		(GBB.Tool.GetClassIcon(entry.class) or "")..
 		"|c"..GBB.Tool.ClassColor[entry.class].colorStr ..
 		entry.name..
 		
@@ -139,9 +139,11 @@ local function EnterHyperlink(self,link,text)
 				GameTooltip_SetDefaultAnchor(GameTooltip,UIParent)
 				GameTooltip:SetOwner(GroupBulletinBoardFrame, "ANCHOR_BOTTOM", 0,-25)
 				GameTooltip:ClearLines()
-				GameTooltip:AddLine(GBB.Tool.IconClass[entry.class]..
+				GameTooltip:AddLine(
+					(GBB.Tool.GetClassIcon(entry.class) or "")..
 					"|c"..GBB.Tool.ClassColor[entry.class].colorStr ..
-					entry.name)			
+					entry.name
+				);			
 				if entry.dungeon then
 					GameTooltip:AddLine(entry.dungeon)
 				end

--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -361,11 +361,12 @@ local function CreateItem(yy,i,doCompact,req,forceHight)
 			prefix="|r"
 		end
 		local ClassIcon=""
-		if GBB.DB.ShowClassIcon and req.class and GBB.Tool.IconClass[req.class] then
+		if GBB.DB.ShowClassIcon and req.class then
 			if doCompact<1  or GBB.DB.ChatStyle then
-				ClassIcon=GBB.Tool.IconClass[req.class]
+				ClassIcon = GBB.Tool.GetClassIcon(req.class) or ""
+
 			else
-				ClassIcon=GBB.Tool.IconClassBig[req.class]
+				ClassIcon = GBB.Tool.GetClassIcon(req.class, 18) or ""
 			end
 		end
 
@@ -705,7 +706,7 @@ function GBB.LfgRequestShowTooltip(self)
 		if GBB.DB.EnableGroup and GBB.GroupTrans and GBB.GroupTrans[req.name] then
 			local entry=GBB.GroupTrans[req.name]
 
-			GameTooltip:AddLine(GBB.Tool.IconClass[entry.class]..
+			GameTooltip:AddLine((GBB.Tool.GetClassIcon(entry.class) or "")..
 				"|c"..GBB.Tool.ClassColor[entry.class].colorStr ..
 				entry.name)
 			if entry.dungeon then

--- a/LFGBulletinBoard/LibGPIToolBox.lua
+++ b/LFGBulletinBoard/LibGPIToolBox.lua
@@ -4,31 +4,24 @@ local Tool=Addon.Tool
 
 Tool.IconClassTexture="Interface\\GLUES\\CHARACTERCREATE\\UI-CHARACTERCREATE-CLASSES"
 Tool.IconClassTextureWithoutBorder="Interface\\WorldStateFrame\\ICONS-CLASSES"
-Tool.IconClassTextureCoord=CLASS_ICON_TCOORDS
-Tool.IconClass={
-  ["WARRIOR"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:0:0:0:0:256:256:0:64:0:64|t",
-  ["MAGE"]=		"|TInterface\\WorldStateFrame\\ICONS-CLASSES:0:0:0:0:256:256:64:128:0:64|t",
-  ["ROGUE"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:0:0:0:0:256:256:128:192:0:64|t",
-  ["DRUID"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:0:0:0:0:256:256:192:256:0:64|t",
-  ["HUNTER"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:0:0:0:0:256:256:0:64:64:128|t",
-  ["SHAMAN"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:0:0:0:0:256:256:64:128:64:128|t",
-  ["PRIEST"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:0:0:0:0:256:256:128:192:64:128|t",
-  ["WARLOCK"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:0:0:0:0:256:256:192:256:64:128|t",
-  ["PALADIN"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:0:0:0:0:256:256:0:64:128:192|t",
-  ["DEATHKNIGHT"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:0:0:0:0:256:256:64:128:128:192|t",
-  }
-Tool.IconClassBig={
-  ["WARRIOR"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:18:18:-4:4:256:256:0:64:0:64|t",
-  ["MAGE"]=		"|TInterface\\WorldStateFrame\\ICONS-CLASSES:18:18:-4:4:256:256:64:128:0:64|t",
-  ["ROGUE"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:18:18:-4:4:256:256:128:192:0:64|t",
-  ["DRUID"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:18:18:-4:4:256:256:192:256:0:64|t",
-  ["HUNTER"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:18:18:-4:4:256:256:0:64:64:128|t",
-  ["SHAMAN"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:18:18:-4:4:256:256:64:128:64:128|t",
-  ["PRIEST"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:18:18:-4:4:256:256:128:192:64:128|t",
-  ["WARLOCK"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:18:18:-4:4:256:256:192:256:64:128|t",
-  ["PALADIN"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:18:18:-4:4:256:256:0:64:128:192|t",
-  ["DEATHKNIGHT"]=	"|TInterface\\WorldStateFrame\\ICONS-CLASSES:18:18:-4:4:256:256:64:128:128:192|t",
-  }  
+
+---@param classFile string
+---@param size number?
+function Tool.GetClassIcon(classFile, size)
+	assert(type(classFile) == "string", "Usage: Tool.GetClassIcon(class: string, size: number?)", classFile)
+	local coords = CLASS_ICON_TCOORDS[classFile:upper()];
+	local size = size or 14;
+	if coords then
+		local icon = CreateTextureMarkup(
+			"Interface\\WorldStateFrame\\ICONS-CLASSES",
+			256, 256, -- og size
+			size, size, -- new size
+			coords[1], coords[2], coords[3], coords[4], -- texCoords
+			0, 1 -- x, y offsets
+		);
+		return icon;
+	end
+end
   
 Tool.RaidIconNames=ICON_TAG_LIST
 Tool.RaidIcon={

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -86,7 +86,7 @@ local function CreateHeader(scrollPos, dungeon)
 	local padY = 4 -- px, vspace around text
 	local bottomMargin = 3 -- px, vspace beneath the header
 	if not header then
-		---@class requestHeader : Frame
+		---@class RequestHeader : Frame
 		header = CreateFrame(
 			"Frame", ItemFrameName,
 			GroupBulletinBoardFrame_ScrollChildFrame, "GroupBulletinBoard_TmpHeader"
@@ -108,9 +108,23 @@ local function CreateHeader(scrollPos, dungeon)
 			GameFontNormalLarge = "GameFontHighlightLarge",
 		}
 		header:SetScript("OnEnter", function(self)
+			---@cast self RequestHeader
+			if GBB.DB.ColorOnLevel then
+				-- save color esacped text
+				self.Name.savedText = self.Name:GetText()
+				local name, levels = self.Name.savedText:match("|c%x%x%x%x%x%x%x%x(.+)|r(.+)");
+				if name then
+					self.Name:SetText(name..(levels or ""))			
+				end
+			end
 			self.Name:SetFontObject(matchedHighlight[GBB.DB.FontSize or "GameFontNormal"])
 		end)
 		header:SetScript("OnLeave", function(self)
+			---@cast self RequestHeader
+			if GBB.DB.ColorOnLevel then
+				-- restore color escaped text
+				self.Name:SetText(self.Name.savedText)			
+			end
 			self.Name:SetFontObject(GBB.DB.FontSize or "GameFontNormal")
 		end)
 		

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -100,6 +100,20 @@ local function CreateHeader(scrollPos, dungeon)
 		header.Name:SetFontObject(GBB.DB.FontSize)
 		header.Name:SetJustifyH("LEFT")
 		header.Name:SetJustifyV("MIDDLE")
+		
+		-- add fontstring highlight on header hover
+		local matchedHighlight = {
+			GameFontNormal = "GameFontHighlight",
+			GameFontNormalSmall = "GameFontHighlightSmall",
+			GameFontNormalLarge = "GameFontHighlightLarge",
+		}
+		header:SetScript("OnEnter", function(self)
+			self.Name:SetFontObject(matchedHighlight[GBB.DB.FontSize or "GameFontNormal"])
+		end)
+		header:SetScript("OnLeave", function(self)
+			self.Name:SetFontObject(GBB.DB.FontSize or "GameFontNormal")
+		end)
+		
 
 		GBB.FramesEntries[dungeon] = header
 	end
@@ -161,6 +175,18 @@ local function CreateItem(yy,i,doCompact,req,forceHight)
 		if GBB.DontTrunicate then
 			GBB.ClearNeeded=true
 		end
+		-- add a light hightlight on mouseover, requires we add a texture child		
+		-- Draw on "HIGHTLIGHT" layer to use base xml highlighting script
+		local hoverTex = GBB.FramesEntries[i]:CreateTexture(nil, "HIGHLIGHT")
+		-- padding used compensate text clipping out of its containing frame
+		local pad = 2 
+		hoverTex:SetPoint("TOPLEFT", -pad, pad)
+		hoverTex:SetPoint("BOTTOMRIGHT", pad, -pad)
+		hoverTex:SetAtlas("search-highlight")
+		hoverTex:SetDesaturated(true) -- its comes blue by default
+		hoverTex:SetVertexColor(1, 1, 1, 0.4)
+		hoverTex:SetBlendMode("ADD")
+
 		GBB.Tool.EnableHyperlink(GBB.FramesEntries[i])
 	end
 

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -196,7 +196,6 @@ local function CreateItem(scrollPos,i,scale,req,forceHeight)
 		entry.Message = _G[ItemFrameName.."_message"] ---@type FontString
 		entry.Time = _G[ItemFrameName.."_time"] ---@type FontString
 		
-
 		entry.Name:SetPoint("TOPLEFT", 0,-1.5)
 		entry.Name:SetFontObject(GBB.DB.FontSize)
 		entry.Time:SetPoint("TOP", entry.Name, "TOP", 0, 0)
@@ -236,6 +235,11 @@ local function CreateItem(scrollPos,i,scale,req,forceHeight)
 	-- request message
 	entry.Message:SetFontObject(GBB.DB.FontSize)
 	entry.Message:SetMaxLines(GBB.DB.DontTrunicate and 99 or 1)
+	entry.Message:SetJustifyV("MIDDLE")
+	entry.Message:ClearAllPoints() -- incase swapped to 2-line mode
+	entry.Message:SetText(" ") 
+	local lineHeight = entry.Message:GetStringHeight() + 1 -- ui nit +1 offset
+	
 	if GBB.DontTrunicate then
 		-- make sure the initial size of the FontString object is big enough
 		-- to allow for all possible text when not truncating
@@ -337,6 +341,7 @@ local function CreateItem(scrollPos,i,scale,req,forceHeight)
 	if scale < 1 then -- aka GBB.DB.CompactStyle
 		entry.Message:SetPoint("TOPLEFT",entry.Name, "BOTTOMLEFT", 0, -2)
 		entry.Message:SetPoint("RIGHT",entry.Time, "RIGHT", 0,0)
+		entry.Message:SetJustifyV("TOP")
 	else
 		entry.Message:SetPoint("TOPLEFT",entry.Name, "TOPRIGHT", 10)
 		entry.Message:SetPoint("RIGHT",entry.Time, "LEFT", -10,0) 
@@ -367,19 +372,14 @@ local function CreateItem(scrollPos,i,scale,req,forceHeight)
 	else
 		if scale < 1 then
 			projectedHeight = entry.Name:GetStringHeight() + entry.Message:GetStringHeight()
-		elseif GBB.DB.DontTrunicate then
-			projectedHeight = entry.Message:GetStringHeight()
-			entry.Message:SetJustifyV("TOP")
 		else
-			projectedHeight = math.max(
-				entry.Message:GetStringHeight(), entry.Name:GetStringHeight()
-			);
-			entry.Message:SetJustifyV("MIDDLE")
+			projectedHeight = GBB.DB.DontTrunicate 
+				and entry.Message:GetStringHeight()
+				or lineHeight;
 		end
 	end
 	if not GBB.DB.DontTrunicate and forceHeight then
 		projectedHeight=forceHeight
-		entry.Message:SetJustifyV("MIDDLE")
 	end
 	
 	-- finally set element heights and return container height
@@ -571,7 +571,7 @@ function GBB.UpdateList()
 						or itemsInCategory < GBB.DB.ShowOnlyNb) -- or limit not reached
 					and doesRequestMatchResultsFilter(req.message) -- matches global results filter
 				then
-					scrollHeight= scrollHeight + CreateItem(scrollHeight,requestIdx,itemScale,req,baseItemHeight) + 3 -- why add 3? 
+					scrollHeight= scrollHeight + CreateItem(scrollHeight,requestIdx,itemScale,req) + 3 -- why add 3? 
 					itemsInCategory = itemsInCategory + 1
 				end
 			end

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -215,7 +215,7 @@ local function CreateItem(scrollPos,i,scale,req,forceHeight)
 		hoverTex:SetPoint("BOTTOMRIGHT", pad, -pad)
 		hoverTex:SetAtlas("search-highlight")
 		hoverTex:SetDesaturated(true) -- its comes blue by default
-		hoverTex:SetVertexColor(0.5, 0.5, 0.5, 0.7)
+		hoverTex:SetVertexColor(0.7, 0.7, 0.7, 0.4)
 		hoverTex:SetBlendMode("ADD")
 		
 		GBB.Tool.EnableHyperlink(entry)
@@ -257,12 +257,8 @@ local function CreateItem(scrollPos,i,scale,req,forceHeight)
 		end
 
 		local ClassIcon=""
-		if GBB.DB.ShowClassIcon and req.class and GBB.Tool.IconClass[req.class] then
-			if scale < 1  or GBB.DB.ChatStyle then
-				ClassIcon=GBB.Tool.IconClass[req.class]
-			else
-				ClassIcon=GBB.Tool.IconClassBig[req.class]
-			end
+		if GBB.DB.ShowClassIcon and req.class then
+			ClassIcon = GBB.Tool.GetClassIcon(req.class, GBB.DB.ChatStyle and 12 or 18) or ""
 		end
 
 		local FriendIcon = (
@@ -1070,7 +1066,7 @@ function GBB.RequestShowTooltip(self)
 		if GBB.DB.EnableGroup and GBB.GroupTrans and GBB.GroupTrans[req.name] then
 			local entry=GBB.GroupTrans[req.name]
 
-			GameTooltip:AddLine(GBB.Tool.IconClass[entry.class]..
+			GameTooltip:AddLine((GBB.Tool.GetClassIcon(entry.class) or "")..
 				"|c"..GBB.Tool.ClassColor[entry.class].colorStr ..
 				entry.name)
 			if entry.dungeon then

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -215,7 +215,7 @@ local function CreateItem(scrollPos,i,scale,req,forceHeight)
 		hoverTex:SetPoint("BOTTOMRIGHT", pad, -pad)
 		hoverTex:SetAtlas("search-highlight")
 		hoverTex:SetDesaturated(true) -- its comes blue by default
-		hoverTex:SetVertexColor(1, 1, 1, 0.4)
+		hoverTex:SetVertexColor(0.5, 0.5, 0.5, 0.7)
 		hoverTex:SetBlendMode("ADD")
 		
 		GBB.Tool.EnableHyperlink(entry)
@@ -248,11 +248,12 @@ local function CreateItem(scrollPos,i,scale,req,forceHeight)
 	
 	--- Fill out the entry frames children with the request data
 	if req then
-		local prefix
+		local formattedName = req.name
+		if GBB.RealLevel[req.name] then
+			formattedName = formattedName.." ("..GBB.RealLevel[req.name]..")"
+		end
 		if GBB.DB.ColorByClass and req.class and GBB.Tool.ClassColor[req.class].colorStr then
-			prefix="|c"..GBB.Tool.ClassColor[req.class].colorStr
-		else
-			prefix="|r"
+			formattedName = WrapTextInColorCode(formattedName, GBB.Tool.ClassColor[req.class].colorStr)
 		end
 
 		local ClassIcon=""
@@ -275,11 +276,6 @@ local function CreateItem(scrollPos,i,scale,req,forceHeight)
 			and string.format(GBB.TxtEscapePicture,GBB.PastPlayerIcon) 
 			or "")
 		);
-
-		local suffix="|r"
-		if GBB.RealLevel[req.name] then
-			suffix=" ("..GBB.RealLevel[req.name]..")"..suffix
-		end
 
 		local now = time()
 		local fmtTime
@@ -317,12 +313,16 @@ local function CreateItem(scrollPos,i,scale,req,forceHeight)
 			end
 		end
 		if GBB.DB.ChatStyle then
-			entry.Name:SetText()
-			entry.Message:SetText(ClassIcon.."["..prefix ..req.name..suffix.."]"..FriendIcon..": "..req.message)
+			entry.Name:SetText("")
+			entry.Message:SetFormattedText("%s\91%s\93%s: %s",
+				ClassIcon, formattedName, FriendIcon, req.message
+			);
+			entry.Message:SetIndentedWordWrap(true)
 		else
-			entry.Name:SetText(ClassIcon..prefix .. req.name .. suffix..FriendIcon)
-			entry.Message:SetText(typePrefix .. suffix .. req.message)
+			entry.Name:SetFormattedText("%s%s%s", ClassIcon, formattedName, FriendIcon)
+			entry.Message:SetFormattedText("%s %s", typePrefix, req.message)
 			entry.Time:SetText(fmtTime)
+			entry.Message:SetIndentedWordWrap(false)
 		end
 
 		entry.Message:SetTextColor(GBB.DB.EntryColor.r,GBB.DB.EntryColor.g,GBB.DB.EntryColor.b,GBB.DB.EntryColor.a)

--- a/LFGBulletinBoard/changelog.txt
+++ b/LFGBulletinBoard/changelog.txt
@@ -2,10 +2,11 @@
 
 Group Bulletin Board 	
 3.3alpha
+ - Added hover highlights on entries and categories to better differentiate the frames the user is about to click.
  - Added a "Random Dungeon" category under "Others" for cataclysm RDF
  - "Tool Request" tab temporarily disabled until it can be fixed
  - Search pattern support for cata dungeons (see Search Patterns in addon settings, only english presets atm)
- - missing localizations for dungeon names added. (includes ptBR)
+ - Missing localizations for dungeon names added. (includes ptBR)
  - Updates to expansion filters in the config panel.
  - fixes to duplicate request with realm names enabled
 


### PR DESCRIPTION
Included in these commits:
- Headers will now use a highlighted text on mouseover
- Request entries will show a highlight texture on mouseover

These commits include annotations for cleanups for the `CreateHeader` and `CreateItem` functions. Goal is to eventually generalize these functions for each tab (when the LFG Tool tab gets fixed)

**images**
before/after (Top => Bottom)
![before](https://i.imgur.com/lZrBdOg.gif)
![after](https://i.imgur.com/qw78ib7.gif) 