### PR TITLE
feature: extended locale support

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -346,6 +346,12 @@ function GBB.CreateTagList ()
 	if GBB.DB.TagsZhcn then
 		GBB.CreateTagListLOC("zhCN")
 	end
+	if GBB.DB.TagsPortuguese then
+		GBB.CreateTagListLOC("ptBR")
+	end
+	if GBB.DB.TagsSpanish then
+		GBB.CreateTagListLOC("esES")
+	end
 	if GBB.DB.TagsCustom then
 		GBB.searchTagsLoc["custom"]=GBB.Split(GBB.DB.Custom.Search)
 		GBB.badTagsLoc["custom"]=GBB.Split(GBB.DB.Custom.Bad)

--- a/LFGBulletinBoard/LibGPIToolBox.lua
+++ b/LFGBulletinBoard/LibGPIToolBox.lua
@@ -1,4 +1,6 @@
-local TOCNAME,Addon = ...
+local TOCNAME,
+	---@class Addon_Tool	
+	Addon = ...;
 Addon.Tool=Addon.Tool or {}
 local Tool=Addon.Tool
 
@@ -64,20 +66,19 @@ for eng,name in pairs(LOCALIZED_CLASS_NAMES_FEMALE) do
 	Tool.NameToClass[name]=eng
 end
 
-local _tableAccents = {
-    ["�"] = "A", ["�"] = "A", ["�"] = "A", ["�"] = "A", ["�"] = "Ae", ["�"] = "A",
-	["�"] = "AE", ["�"] = "C", ["�"] = "E", ["�"] = "E", ["�"] = "E", ["�"] = "E", 
-	["�"] = "I", ["�"] = "I", ["�"] = "I", ["�"] = "I", ["�"] = "D", ["�"] = "N", 
-	["�"] = "O", ["�"] = "O", ["�"] = "O", ["�"] = "O", ["�"] = "Oe", ["�"] = "O", 
-	["�"] = "U", ["�"] = "U", ["�"] = "U", ["�"] = "Ue", ["�"] = "Y", ["�"] = "P", 
-	["�"] = "s", ["�"] = "a", ["�"] = "a", ["�"] = "a", ["�"] = "a", ["�"] = "ae", 
-	["�"] = "a", ["�"] = "ae", ["�"] = "c", ["�"] = "e", ["�"] = "e", ["�"] = "e", 
-	["�"] = "e", ["�"] = "i", ["�"] = "i", ["�"] = "i", ["�"] = "i", ["�"] = "eth", 
-	["�"] = "n", ["�"] = "o", ["�"] = "o", ["�"] = "o", ["�"] = "o", ["�"] = "oe", 
-	["�"] = "o", ["�"] = "u", ["�"] = "u", ["�"] = "u", ["�"] = "ue", ["�"] = "y", 
-	["�"] = "p", ["�"] = "y", ["�"] = "ss",
-	}
-
+local transliterations = {
+    ["À"] = "A", ["Á"] = "A", ["Â"] = "A", ["Ã"] = "A", ["Ä"] = "Ae", ["Å"] = "A",
+	["Æ"] = "AE", ["Ç"] = "C", ["È"] = "E", ["É"] = "E", ["Ê"] = "E", ["Ë"] = "E", 
+	["Ì"] = "I", ["Í"] = "I", ["Î"] = "I", ["Ï"] = "I", ["Ð"] = "D", ["Ñ"] = "N", 
+	["Ò"] = "O", ["Ó"] = "O", ["Ô"] = "O", ["Õ"] = "O", ["Ö"] = "Oe", ["Ø"] = "O", 
+	["Ù"] = "U", ["Ú"] = "U", ["Û"] = "U", ["Ü"] = "Ue", ["Ý"] = "Y", ["Þ"] = "P", 
+	["ẞ"] = "s", ["à"] = "a", ["á"] = "a", ["â"] = "a", ["ã"] = "a", ["ä"] = "ae", 
+	["å"] = "a", ["æ"] = "ae", ["ç"] = "c", ["è"] = "e", ["é"] = "e", ["ê"] = "e", 
+	["ë"] = "e", ["ì"] = "i", ["í"] = "i", ["î"] = "i", ["ï"] = "i", ["ð"] = "eth", 
+	["ñ"] = "n", ["ò"] = "o", ["ó"] = "o", ["ô"] = "o", ["õ"] = "o", ["ö"] = "oe", 
+	["ø"] = "o", ["ù"] = "u", ["ú"] = "u", ["û"] = "u", ["ü"] = "ue", ["ý"] = "y", 
+	["þ"] = "p", ["ÿ"] = "y", ["ß"] = "ss",
+}
 -- Hyperlink
 
 local function EnterHyperlink(self,link,text)
@@ -266,8 +267,11 @@ function Tool.iMerge(t1,...)
 	return t1
 end
 
+---Replaces special characters and characters with accents from a given string.
+---@param str string
+---@return string, number
 function Tool.stripChars(str)
-	return string.gsub(str,"[%z\1-\127\194-\244][\128-\191]*", _tableAccents)
+	return string.gsub(str,"[%z\1-\127\194-\244][\128-\191]*", transliterations)
 end
 
 function Tool.CreatePattern(pattern,maximize)		

--- a/LFGBulletinBoard/Localization.lua
+++ b/LFGBulletinBoard/Localization.lua
@@ -63,6 +63,10 @@ local preLocalizedFallbacks = {
 
 	["TabRequest"]= LFGUILD_TAB_REQUESTS_NONE, --"Requests"
 	["TabGroup"] = MEMBERS,
+
+	-- Language checkboxes 
+	["CboxTagsPortuguese"] = LFG_LIST_LANGUAGE_PTBR,
+	["CboxTagsSpanish"] = LFG_LIST_LANGUAGE_ESES,
 }
 
 ---Localized addon strings, keyed by locale
@@ -828,6 +832,9 @@ function GBB.LocalizationInit()
 			local clientStr = preLocalizedFallbacks[key]
 			return clientStr or englishStr or "["..key.."]"
 		end})
+	else -- insert new any *new* game translations to enUS/enGB
+		-- could also just manually insert them to the `GBB.locales.enGB` table
+		setmetatable(GBB.locales.enUS, {__index = preLocalizedFallbacks})
 	end
 	return localizedStrings
 end

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -1,5 +1,5 @@
 local TOCNAME,
-	---@class Addon
+	---@class Addon_Options : Addon_Localization
 	GBB= ...;
 local ChannelIDs
 local ChkBox_FilterDungeon
@@ -14,7 +14,8 @@ local PROJECT_EXPANSION_ID = {
 	[WOW_PROJECT_CATACLYSM_CLASSIC or 0] = GBB.Enum.Expansions.Cataclysm,
 }
 local EXPANSION_PROJECT_ID = tInvert(PROJECT_EXPANSION_ID)
-
+---hack to remove "World of Warcraft: " from classic on esES/esMX clients
+local EXPANSION_NAME0 = EXPANSION_NAME0:gsub("World of Warcraft: ", "")
 local EXPANSION_FILTER_NAME = {
 	[GBB.Enum.Expansions.Classic] = SUBTITLE_FORMAT:format(FILTERS, EXPANSION_NAME0),
 	[GBB.Enum.Expansions.BurningCrusade] = SUBTITLE_FORMAT:format(FILTERS, EXPANSION_NAME1),
@@ -386,11 +387,11 @@ function GBB.OptionsInit ()
 	GenerateExpansionPanel(GBB.Enum.Expansions.Classic)
 		
 	----------------------------------------------------------
-	-- Tags
+	-- Language Tags and Search Patterns
 	----------------------------------------------------------
 	GBB.Options.AddPanel(GBB.L["PanelTags"],false,true)
 	
-	GBB.Options.AddCategory(GBB.L["HeaderTags"])
+	GBB.Options.AddCategory(LANGUAGES_LABEL)
 	GBB.Options.Indent(10)
 	GBB.Options.InLine()
 	local locale = GetLocale()
@@ -400,7 +401,11 @@ function GBB.OptionsInit ()
 	CheckBox("TagsFrench", locale == "frFR")
 	CheckBox("TagsZhtw",locale == "zhTW")
 	CheckBox("TagsZhcn",locale == "zhCN")
-
+	GBB.Options.EndInLine()
+	GBB.Options.InLine()
+	-- hack: add ptBR, and esES/esMX checkboxes
+	CheckBox("TagsSpanish", locale == "esES" or locale == "esMX")
+	CheckBox("TagsPortuguese", locale == "ptBR")
 	CheckBox("TagsCustom",true)
 	GBB.Options.EndInLine()
 	GBB.Options.Indent(-10)
@@ -433,11 +438,11 @@ function GBB.OptionsInit ()
 	GBB.Options.AddSpace()
 	local locales= GBB.locales.enGB
 	local t={}
-	for key,value in pairs(locales) do 
+	for key, _ in pairs(locales) do 
 		table.insert(t,key)
 	end
 	table.sort(t)
-	for i,key in ipairs(t) do 
+	for _,key in ipairs(t) do 
 		
 		local col=GBB.L[key]~=nil and "|cffffffff" or "|cffff4040"
 		local txt=GBB.L[key.."_org"]~="["..key.."_org]" and GBB.L[key.."_org"] or GBB.L[key]

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -33,6 +33,8 @@ local suffixTags = {
 	frFR = "groupe",
 	zhTW = "",
 	zhCN = "",
+	esES = "",
+	ptBR = ""
 }
 
 --- Search Tags: usually prepended to an looking for group chat message, ie the "lfg" in "lfg wailing caverns"
@@ -46,6 +48,8 @@ local searchTags = {
 
 	zhTW = "缺 來 找 徵 坦 補 DD 輸出 戰 聖 薩 獵 德 賊 法 牧 術",
 	zhCN = "= 缺 来 找 德 T N ND DZ FS SS SM",
+	esES = "buscando grupo bm bdg bg",
+	ptBR = "procurando grupo pm pg"
 }
 
 --- Bad Tags: for messages to ignore which may have matched a searchTag, like
@@ -57,6 +61,8 @@ local badTags = {
 	frFR = "",
 	zhTW = "影布 回流",
 	zhCN = "影布 回流",
+	esES = "",
+	ptBR = ""
 }
 
 --- Heroic Tags: for identifying dungeon/raid difficulties
@@ -67,6 +73,8 @@ local heroicTags = {
 	frFR = "h hc heroic hm hero heroique",
 	zhTW = "h 英雄",
 	zhCN = "h H 英雄",
+	esES = "h hc heroico heroica",
+	ptBR = "h hc heroico",
 }
 
 --- Dungeon Tags: for identifying dungeons related to messages.
@@ -78,6 +86,8 @@ local dungeonTags = {
 		frFR = nil,
 		zhTW = "RAQ AQ20 廢墟",
 		zhCN = "FX 废墟",
+		esES = "",
+		ptBR = ""
 	},
 	AQ40 = { -- Ahn'Qiraj Temple
 		enGB = "aq40",

--- a/LFGBulletinBoard/changelog.txt
+++ b/LFGBulletinBoard/changelog.txt
@@ -1,14 +1,14 @@
---[[
+Group Bulletin Board
 
-Group Bulletin Board 	
-3.3alpha
- - Added hover highlights on entries and categories to better differentiate the frames the user is about to click.
- - Added a "Random Dungeon" category under "Others" for cataclysm RDF
- - "Tool Request" tab temporarily disabled until it can be fixed
- - Search pattern support for cata dungeons (see Search Patterns in addon settings, only english presets atm)
- - Missing localizations for dungeon names added. (includes ptBR)
- - Updates to expansion filters in the config panel.
- - fixes to duplicate request with realm names enabled
+3.3
+ - Language support for `ptBR` and `esES`/`esMX` added. (Contributions for presets welcomed)
+ - Updates to settings translations for non-english clients.
+ - Fixes to pattern matching for messages with accented characters.
+ - Added hover highlights on entries and categories.
+ - "Tool Request" tab temporarily disabled until fixed
+ - English presets for Cataclysm dungeons Added.
+ - Filter settings for Cataclysm dungeons Added.
+ - Fixes to duplicate request with realm names enabled
 
 3.24  
  - All credit goes to juemrami for all the fixes.
@@ -281,5 +281,3 @@ Group Bulletin Board
 - option "Show a fixed number of requests"
 - option "Chat Style"
 - About-Panel
-		
-]]--

--- a/LFGBulletinBoard/dungeons/cata.lua
+++ b/LFGBulletinBoard/dungeons/cata.lua
@@ -483,16 +483,23 @@ function addon.GetSortedDungeonKeys(expansionID, typeID)
 			tinsert(keys, tagKey)
 		end
 	end
-		table.sort(keys, function(keyA, keyB)
+	local isRated = { -- move this to a trait on the info table
+		RBG = true,
+		ARENA = true
+	}
+	table.sort(keys, function(keyA, keyB)
 		local infoA = infoByTagKey[keyA];
         local infoB = infoByTagKey[keyB];
         if infoA.typeID == infoB.typeID then
             if infoA.minLevel == infoB.minLevel then
                 if infoA.maxLevel == infoB.maxLevel then
 					-- Edge case: Sort RBGS and ARENAS *after* normal bgs.
-					if infoA.typeID == DungeonType.Battleground then
-						return keyB == "RBG" or keyB == "ARENA"
+					if not isRated[keyA] and isRated[keyB] then
+						return true
+					elseif isRated[keyA] and not isRated[keyB] then
+						return false
 					end
+
                     if infoA.name == infoB.name then
                         return keyA < keyB
                     else return infoA.name < infoB.name end


### PR DESCRIPTION
This PR adds basic locale support for esES, esMX, and ptBR to the addon.

**Related issues**:
  - #191
  
**Notes**:
  - It **does not** add any preset search patterns for categorizing chat messages, those are required to be contributed as i dont play on these locales.
	  - `esES` and `esMX` share a table for preset atm, open to splitting it if requested.
  - Not all addon configuration display strings are translated, only the few which had usable alternatives in client global tables (see available strings here [wago.tools/db2/GlobalStrings](https://wago.tools/db2/GlobalStrings?build=4.4.0.54986&filter[Flags]=1|3))
  -  Previously manually translated display strings in `Localization.lua` **will not** be used over the game provided translations in global strings for client locales that had them **for non-english clients**.
	  - Plan to move away from these manual "translations" in the `GBB.locales.enGB` table as well, except where necessary (ie strings explaining more detailed addon related information). 
	  - See [f0a4b70](https://github.com/Vysci/LFG-Bulletin-Board/pull/242/commits/f0a4b707db4fcb76e6884fd56f9849e0bee78bdc) for the currently matched translations