### PR TITLE
feat: Custom User Filters Support

### DIFF
--- a/LFGBulletinBoard/CustomCategories.lua
+++ b/LFGBulletinBoard/CustomCategories.lua
@@ -1,0 +1,132 @@
+local TOCNAME,
+    ---@class Addon_CustomFilters
+    Addon = ...;
+
+local HIDDEN_LEVEL_RANGE = { 0, 100 };
+
+local isModuleInitialized = false
+local isInitializedOrPanic = function()
+    assert(isModuleInitialized, "CustomFilters module not initialized yet, should call `Addon:InitializeCustomFilters()` after saved variables are available")
+end
+
+---@alias Locale "enUS"|"enGB"|"deDE"|"ruRU"|"frFR"|"zhTW"|"zhCN"|"ptBR"|"esES"|"koKR"
+
+---@class CustomFilter
+---@field name string
+---@field key string
+---@field tags table<Locale, string>
+---@field levels {[1]: number, [2]: number}
+---@field sortIdx number
+---@field isHidden boolean? # `true` if the preset should be completely hidden from the user
+
+---@type {[string]: CustomFilter}
+local presets = {
+    ["BOOSTS"] = {
+        name = "Boosting Services",
+        key = "BOOSTS",
+        tags = {
+            enUS = "boost boosting" ,
+        },
+        levels = CopyTable(HIDDEN_LEVEL_RANGE),
+        isHidden = nil,
+        sortIdx = 1,
+    }
+}
+
+
+function Addon.InitializeCustomFilters()
+    assert(GroupBulletinBoardDB, "`GroupBulletinBoardDB` not found in `InitializeCustomFilters()`. Initialize *after* ADDON_LOADED event")
+    if not GroupBulletinBoardDB.CustomFilters then
+        ---@type {[string]: CustomFilter}
+        GroupBulletinBoardDB.CustomFilters = CopyTable(presets)
+    end
+    -- insert any enabled presets into the `CustomFilters` table
+    for key, preset in pairs(presets) do
+        local store = GroupBulletinBoardDB.CustomFilters[key]
+        if not store and not preset.isHidden then
+            GroupBulletinBoardDB.CustomFilters[key] = CopyTable(preset)
+        end
+    end
+    -- use this point to perform any db migrations. Like removing deprecated keys.
+    local invalidKeys = {}
+    for _, entry in pairs(GroupBulletinBoardDB.CustomFilters) do
+        -- invalid entries
+        if not entry.name or entry.name == "" then
+            if entry.key then entry.name = entry.key
+            else tinsert(invalidKeys, entry.key) end
+        end
+    end
+    for _, key in ipairs(invalidKeys) do
+        GroupBulletinBoardDB.CustomFilters[key] = nil
+    end
+
+    isModuleInitialized = true
+end
+
+---@return string[] keys Sorted keys
+function Addon.GetCustomFilterKeys()
+    isInitializedOrPanic()
+    local savedFilters = GroupBulletinBoardDB.CustomFilters
+    local keys = {}
+    for key, entry in pairs(savedFilters) do
+        if not entry.isHidden then 
+            table.insert(keys, key) 
+        end
+    end
+    table.sort(keys, function(a, b) 
+        a, b = savedFilters[a], savedFilters[b]
+        if a.sortIdx == b.sortIdx then
+            return a.key < b.key
+        else return a.sortIdx < b.sortIdx end
+    end)
+    return keys
+end
+
+---@param tagListByLoc {[Locale]: {[string]: string[]}}
+---@return boolean anyAdded `true` if any tags were inserted into the tag list
+function Addon.AddCustomFilterTags(tagListByLoc)
+    isInitializedOrPanic()
+    local filterKeys = Addon.GetCustomFilterKeys()
+    local customFiltersDB = GroupBulletinBoardDB.CustomFilters
+    local anyAdded = false
+    for _, customKey in ipairs(filterKeys) do
+        local entry = customFiltersDB[customKey]
+        -- hack: add enGB entries for enUS.(tagListByLoc expects enGB)          
+        -- should move away from enGB to enUS at some point. GetLocale never returns enGB
+        entry.tags.enGB = entry.tags.enUS
+        for locale, tagList in pairs(tagListByLoc) do
+            if entry.tags[locale] then
+                tagList[entry.key] = {strsplit(" ", entry.tags[locale])}
+                anyAdded = true
+            end
+        end
+    end
+    return anyAdded
+end
+
+---@return {[string]: string} nameList map of `[tagKey] => displayName`
+function Addon.GetCustomFilterNames()
+    local nameList = {}
+    isInitializedOrPanic()
+    local filterKeys = Addon.GetCustomFilterKeys()
+    local customFiltersDB = GroupBulletinBoardDB.CustomFilters
+    for _, key in ipairs(filterKeys) do
+        local entry = customFiltersDB[key]
+        nameList[entry.key] = entry.name
+    end
+    return nameList
+end
+
+function Addon.GetAllCustomFilterLevels()
+    isInitializedOrPanic()
+    local customFilterDB = GroupBulletinBoardDB.CustomFilters
+    local keys = Addon.GetCustomFilterKeys()
+    local ranges = {}
+    for _, key in ipairs(keys) do
+        local entry = customFilterDB[key]
+        if entry.levels then
+            ranges[key] = entry.levels
+        end
+    end
+    return ranges
+end

--- a/LFGBulletinBoard/CustomCategories.lua
+++ b/LFGBulletinBoard/CustomCategories.lua
@@ -2,12 +2,25 @@ local TOCNAME,
     ---@class Addon_CustomFilters
     Addon = ...;
 
+-- Note on verbiage: Here im considering the "store" to be a category's entry table in the savedVars 
+-- ie `store = GroupBulletBoard.CustomFilters[key]`. Also, a "Category" == a "Filter"   
+
 local HIDDEN_LEVEL_RANGE = { 0, 100 };
 
 local isModuleInitialized = false
 local isInitializedOrPanic = function()
     assert(isModuleInitialized, "CustomFilters module not initialized yet, should call `Addon:InitializeCustomFilters()` after saved variables are available")
 end
+local USER_KEY_BASE = "USER_CATEGORY_%i" 
+local USER_KEY_IDX_CAPTURE = "USER_CATEGORY_(%d+)"
+
+-- "Learning this trait will lock you to this path.|nThis can't be undone."" => "|nThis can't be undone."
+-- note: remember check for zh the "period". Also, missing newline in deDE so fallback to empty string.
+local PERMANENT_ACTION_WARNING = RELIC_FORGE_CONFIRM_TRAIT_FIRST_TIME:match("\124.+[。%.]") or ""
+local CONFIRM_REMOVAL = CONFIRM_GLYPH_REMOVAL:gsub("%%s", "\"%%s\"") -- "Are you sure you want to remove \"%s\"?"
+---@type "Are you sure you want to remove \"%s\"?|nThis action cannot be undone."
+local FILTER_REMOVAL_WARNING = CONFIRM_REMOVAL..PERMANENT_ACTION_WARNING 
+local CHARACTER_SPECIFIC_SYMBOL = "\42" -- "*"
 
 ---@alias Locale "enUS"|"enGB"|"deDE"|"ruRU"|"frFR"|"zhTW"|"zhCN"|"ptBR"|"esES"|"koKR"
 
@@ -129,4 +142,539 @@ function Addon.GetAllCustomFilterLevels()
         end
     end
     return ranges
+end
+
+local updateRelatedAddonData = function(tagsOnly)
+    ---@cast Addon Addon_GroupBulletinBoard
+	-- Get localize and Dungeon-Information
+	assert(Addon.dungeonNames and Addon.dungeonTagsLoc and Addon.dungeonSort,
+        "Verify all addon data is loaded before calling this function"
+    );
+    if not tagsOnly then  -- tags are done in OnEnterPressed event for the editbox
+        -- Add custom categories to `dungeonNames`
+        MergeTable(Addon.dungeonNames, Addon:GetCustomFilterNames());
+        -- add custom categories to levels table
+        MergeTable(Addon.dungeonLevel, Addon:GetAllCustomFilterLevels());
+        -- add custom categories to `dungeonSort` (add internally)
+        ---@diagnostic disable-next-line: redundant-parameter
+        Addon.dungeonSort = Addon.GetDungeonSort(Addon:GetCustomFilterKeys());
+    end
+    -- Add tags for custom categories into `dungeonTagsLoc`. 
+    Addon.AddCustomFilterTags(Addon.dungeonTagsLoc);
+    Addon.CreateTagList()
+                            
+end
+local AddNewFilterToStore = function(name)
+    local entries = GroupBulletinBoardDB.CustomFilters
+    local getNextKey = function()
+        local keys = Addon:GetCustomFilterKeys()
+        for _, key in ipairs(keys) do
+            if not presets[key] then
+                local idx = key:match(USER_KEY_IDX_CAPTURE)
+                local nextKey 
+                repeat
+                    idx = (tonumber(idx) or 0) + 1
+                    nextKey = (USER_KEY_BASE):format(idx)
+                until not GroupBulletinBoardDB.CustomFilters[nextKey]
+                return nextKey
+            end
+        end
+        return USER_KEY_BASE:format(1)
+    end
+    -- insert at the top of the sorted list
+    for _, entry in pairs(entries) do
+        entry.sortIdx = entry.sortIdx + 1
+    end
+    local new = {
+        name = name,
+        tags = {},
+        levels = CopyTable(HIDDEN_LEVEL_RANGE),
+        key = getNextKey(),
+        sortIdx =  1,
+    }
+    entries[new.key] = new
+end
+local fixSavedFiltersSorts = function() 
+    local savedFilters = GroupBulletinBoardDB.CustomFilters
+    local keys = Addon.GetCustomFilterKeys()
+    local sortIdx = 1
+    for _, key in ipairs(keys) do
+        local entry = savedFilters[key]
+        entry.sortIdx = sortIdx
+        sortIdx = sortIdx + 1
+    end
+end
+local dungeonPanelFilterHandles
+--- These checkboxes for these filters are also available in the dungeons panel. Keep state in sync.
+---@param key string
+---@return CheckButton?
+local getAlternateCheckbox = function(key)
+    ---@cast Addon Addon_LibGPIOptions
+    assert(Addon.Options.Vars, "This function should be called after options have been initialized")
+    if not dungeonPanelFilterHandles then
+        dungeonPanelFilterHandles = tInvert(Addon.Options.Vars) 
+    end
+    return _G[dungeonPanelFilterHandles["FilterDungeon"..key]]
+end
+
+---@param direction "up" | "down"
+local moveSortPosition = function(key, direction)
+    -- "up" means higher prio == lower index
+    -- "down" means lower prio == higher index
+    local savedFilters = GroupBulletinBoardDB.CustomFilters
+    local entry = savedFilters[key]
+    -- hack: since fixSavedFiltersSorts re-indexes sort indexes
+    -- we only need to increase the sort index of this entry to be above the next
+    entry.sortIdx = entry.sortIdx + (direction == "up" and -1.5 or 1.5)
+    fixSavedFiltersSorts()
+end
+
+local removeFilterFromRequestList = function(key) ---@param key string
+    -- Note: Users will get errors if any entries in the current RequestList use a key- 
+    -- that is then removed from the dungeonSort table.
+    assert(Addon.RequestList, "RequestList dne. Make sure Addon has been initialized.")
+    ---@cast Addon Addon_RequestList
+    local requestList = {}
+    local anyRemoved = false
+    for _, req in ipairs(Addon.RequestList) do
+        if req.dungeon ~= key then
+            tinsert(requestList, req)
+        else anyRemoved = true end
+    end
+    if anyRemoved then
+        Addon.RequestList = requestList
+        Addon.UpdateList()
+    end
+end
+
+StaticPopupDialogs["GBB_CREATE_CATEGORY"] = {
+    text = ENTER_FILTER_NAME,
+    button1 = CREATE,
+    button2 = CANCEL,
+    OnButton1 = function(self, data)
+        PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
+		local name = strtrim(self.editBox:GetText());
+		AddNewFilterToStore(name);
+        updateRelatedAddonData()
+        Addon.UpdateAdditionalFiltersPanel(data.panel)
+    end,
+    EditBoxOnTextChanged = function(self)
+		if (strtrim(self:GetText()) == "" ) then
+			self:GetParent().button1:Disable();
+		else
+			self:GetParent().button1:Enable();
+		end
+	end,
+    EditBoxOnEnterPressed = function(self)
+		local name = strtrim(self:GetText());
+        if name == "" then return end
+        PlaySound(SOUNDKIT.IG_MAINMENU_OPEN);
+		AddNewFilterToStore(name);
+        updateRelatedAddonData()
+        Addon.UpdateAdditionalFiltersPanel(self:GetParent().data.panel)
+		self:GetParent():Hide();
+	end,
+    OnShow = function(self)
+        self.button1:SetEnabled(false)
+    end,
+	hideOnEscape = 1,
+	hasEditBox = 1,
+	maxLetters = 31
+}
+StaticPopupDialogs["GBB_RENAME_CATEGORY"] = {
+    text = ENTER_FILTER_NAME,
+    button1 = PET_RENAME,
+    button2 = CANCEL,
+    OnButton1 = function(self, data)
+        ---@cast data {settings: FilterSettingsPool, key: string, options: Frame}
+        local entry = GroupBulletinBoardDB.CustomFilters[data.key]
+		if not entry then return end
+		local name = strtrim(self.editBox:GetText());
+        if name == "" then return end
+        entry.name = name
+        data.settings:UpdateFilterState(data.options, entry)
+        updateRelatedAddonData()
+    end,
+    EditBoxOnTextChanged = function(self)
+		if (strtrim(self:GetText()) == "" ) then
+			self:GetParent().button1:Disable();
+		else
+			self:GetParent().button1:Enable();
+		end
+	end,
+    EditBoxOnEnterPressed = function(self)
+		local name = strtrim(self:GetText());
+        if name == "" then return end
+        ---@type {settings: FilterSettingsPool, key: string, options: Frame}
+        local data = self:GetParent().data
+        local entry = GroupBulletinBoardDB.CustomFilters[data.key]
+        if not entry then return end
+        entry.name = name
+        data.settings:UpdateFilterState(data.options, entry)
+        updateRelatedAddonData()
+        self:GetParent():Hide();
+	end,
+    OnShow = function(self)
+        self.button1:SetEnabled(false)
+    end,
+	hideOnEscape = true,
+	hasEditBox = 1,
+	maxLetters = 31
+}
+StaticPopupDialogs["GBB_DELETE_CATEGORY"] = {
+    text = FILTER_REMOVAL_WARNING,
+    button1 = ACCEPT,
+    button2 = CANCEL,
+    OnButton1 = function(self, data)
+        local saved = GroupBulletinBoardDB.CustomFilters[data.key]
+        if not saved then return end -- nothing to delete
+        if presets[data.key] then
+            -- reset to base state, and disable
+            saved = CopyTable(presets[data.key])
+            saved.isHidden = true
+            GroupBulletinBoardDB.CustomFilters[data.key] = saved
+        else
+            GroupBulletinBoardDB.CustomFilters[data.key] = nil 
+        end
+        GroupBulletinBoardDBChar["FilterDungeon"..data.key] = nil
+        fixSavedFiltersSorts()
+        updateRelatedAddonData()
+        removeFilterFromRequestList(data.key)
+        Addon.UpdateAdditionalFiltersPanel(data.panel)
+    end,
+    hideOnEscape = true,
+    timeout = 30,
+}
+
+---@param parent Frame
+---@param direction "Up" | "Down"
+local createMoveFilterButton = function(parent, direction)
+    local buttonName = "$parentMoveFilter".. direction .. "Button"
+    local button = CreateFrame("Button", buttonName, parent);
+    button:SetSize(28, 28);
+    button:SetScript("OnClick", function(self)
+        self.func();
+        PlaySound(SOUNDKIT.U_CHAT_SCROLL_BUTTON);
+    end);
+    button:SetNormalTexture([[Interface\ChatFrame\UI-ChatIcon-Scroll]].. direction .. "-Up");
+    button:SetPushedTexture([[Interface\ChatFrame\UI-ChatIcon-Scroll]].. direction .. "-Down");
+    button:SetDisabledTexture([[Interface\ChatFrame\UI-ChatIcon-Scroll]].. direction .. "-Disabled");
+    button:SetHighlightTexture([[Interface\Buttons\UI-Common-MouseHilight]], "ADD");
+    return button;
+end
+local displayLocales = {"enUS", "deDE", "ruRU", "frFR", "zhTW", "zhCN", "esES", "ptBR"}
+local isLocaleUserEnabled = function(locale)
+    assert(GroupBulletinBoardDB, "GroupBulletinBoardDB not yet loaded. Call this function after initialization.", locale)
+    local enabledLocales = {
+        enGB = GroupBulletinBoardDB.TagsEnglish,
+        enUS = GroupBulletinBoardDB.TagsEnglish,
+        deDE = GroupBulletinBoardDB.TagsGerman,
+        ruRU = GroupBulletinBoardDB.TagsRussian,
+        frFR = GroupBulletinBoardDB.TagsFrench,
+        zhTW = GroupBulletinBoardDB.TagsZhtw,
+        zhCN = GroupBulletinBoardDB.TagsZhcn,
+        esES = GroupBulletinBoardDB.TagsSpanish,
+        esMX = GroupBulletinBoardDB.TagsSpanish,
+        ptBR = GroupBulletinBoardDB.TagsPortuguese,
+    }
+    return enabledLocales[locale]
+end
+---@class FilterSettingsPool
+local FilterSettingsPool = {
+    entries = {},
+    spacers = {},
+    parent = nil, ---@type Frame?
+    create = nil,
+    legend = nil,
+    AddFilterOptions = function(self, key, parent)
+        local self = self ---@class FilterSettingsPool
+        if not self.parent then self.parent = parent end
+        if not self.entries[key] then
+            ---@class FilterOptions : Frame, {SetFixedWidth:function, Layout:function}
+            local options = CreateFrame("Frame", "$parent"..key, parent, "ResizeLayoutFrame");
+            options.header = options:CreateFontString("$parentName", "OVERLAY", "GameFontNormalLarge")
+            options.directions = options:CreateFontString("$parentDirections", "OVERLAY", "GameFontNormalTiny")
+            ---@type Frame|{SetFixedWidth:function, Layout:function}|{[Locale]: EditBox|{label:FontString}}
+            options.patterns = CreateFrame("Frame", "$parentPatterns", options, "ResizeLayoutFrame")
+            options.delete = CreateFrame("Button", "$parentDelete", options, "UIPanelButtonTemplate") --[[@as UIPanelButtonTemplate]]
+            options.rename = CreateFrame("Button", "$parentRename", options, "UIPanelButtonTemplate") --[[@as UIPanelButtonTemplate]]
+            ---@type Frame|{up:Button|{func:function}, down:Button|{func:function}}
+            options.sorts = CreateFrame("Frame", "$parentSorts", options, "ResizeLayoutFrame")
+            options.sorts.up = createMoveFilterButton(options.sorts, "Up")
+            options.sorts.down = createMoveFilterButton(options.sorts, "Down")
+            options.sorts.up:SetPoint("TOP")
+            options.sorts.down:SetPoint("TOP", options.sorts.up, "BOTTOM", 0, -4)
+            ---@type CheckButton|{Text:FontString, func:function, tooltip:string?}
+            options.toggle = CreateFrame("CheckButton", "$parentEnable", options, "ChatConfigCheckButtonTemplate")  
+            options.toggle.Text:ClearAllPoints()
+            options.toggle.Text:SetPoint("RIGHT", options.toggle, "LEFT")
+            parent:HookScript("OnShow", function()
+                Addon.UpdateAdditionalFiltersPanel(parent)
+            end)
+            self.entries[key] = options
+        end
+        return self:InitFilterOptions(self.entries[key])
+    end,
+    ---@param options FilterOptions
+    InitFilterOptions = function(self, options)
+        local padding = 4
+        options.header:SetText(" ")
+        options.header:SetHeight(options.header:GetStringHeight())
+        options.header:SetPoint("TOP", options, "TOP", 0, -padding*2);
+
+        options.directions:SetPoint("BOTTOMLEFT", options.patterns, "TOPLEFT", 0, 2)
+        options.directions:SetTextColor(1, 0, 0, 0) -- keep shown but 0 alpha to take up space.
+        options.directions:SetText(Addon.L.SAVE_ON_ENTER)
+        
+        options.patterns:SetPoint("CENTER", options, "CENTER")
+        for _, locale in ipairs(displayLocales) do
+            local editBox = options.patterns[locale] 
+                or CreateFrame("EditBox", "$parent"..locale.."EditBox", options.patterns, "InputBoxTemplate");
+            editBox:SetFontObject("GameFontNormal")
+            editBox.label = editBox.label or editBox:CreateFontString(
+                "$parentLabel", "OVERLAY", "GameFontNormalSmall"
+            );
+            editBox:SetHeight(16)
+            editBox:SetTextColor(1,1,1,1)
+            editBox:SetJustifyV("MIDDLE")
+            editBox.label:SetHeight(editBox:GetHeight())
+            editBox.label:SetJustifyV("MIDDLE")
+            editBox:SetAutoFocus(false)
+            editBox:Hide() -- hides label
+            options.patterns[locale] = editBox
+        end
+
+        options.toggle:SetSize(28, 28)
+        options.toggle:SetPoint("TOPRIGHT", options, "TOPRIGHT", -padding, -padding)
+        options.toggle.Text:SetFormattedText("%s%s", ENABLE, CHARACTER_SPECIFIC_SYMBOL)
+        options.sorts:SetPoint("TOP", options.toggle, "BOTTOM")
+        
+        options.rename:SetText(PET_RENAME) -- "Rename"
+        options.rename:FitToText()
+        options.rename:SetPoint("LEFT", options.delete, "RIGHT", 10, 0)
+        
+        options.delete:SetText(DELETE)
+        options.delete:FitToText()
+        options.delete:SetPoint("TOP", options.patterns, "BOTTOM", -(options.rename:GetWidth()+10)/2, -15)
+        return options
+    end,
+    ---@param options FilterOptions
+    ---@param dbEntry CustomFilter # reference to settings store for this category entry
+    UpdateFilterState = function(self, options, dbEntry)
+        local self = self ---@class FilterSettingsPool
+        local EDITBOX_WIDTH = 400
+        local LABEL_WIDTH = 75
+        local spacing = 6
+        local filterEnabled = GroupBulletinBoardDBChar["FilterDungeon"..dbEntry.key] or false
+        local hColor = filterEnabled and NORMAL_FONT_COLOR or DISABLED_FONT_COLOR
+       
+        options.header:SetText(dbEntry.name)
+        options.header:SetTextColor(hColor:GetRGBA())
+        options.rename:SetScript("OnClick", function()
+            StaticPopup_Show("GBB_RENAME_CATEGORY", nil, nil, {
+                settings = self,
+                key = dbEntry.key,
+                options = options,
+            })
+        end)
+        options.toggle:SetChecked(filterEnabled)
+        options.patterns:SetFixedWidth(EDITBOX_WIDTH + LABEL_WIDTH*2)
+        local nextAnchor = options.patterns 
+        for _, locale in pairs(displayLocales) do -- fill out pattern editboxes with tags
+            if isLocaleUserEnabled(locale) then
+                local tagString = dbEntry.tags[locale]
+                ---@type EditBox|{label:FontString}
+                local editBox = options.patterns[locale] 
+                options.directions:SetPoint("LEFT", editBox, "LEFT")
+                editBox:SetText(tagString or "")
+                editBox:SetWidth(EDITBOX_WIDTH)
+                if filterEnabled then
+                    editBox:SetTextColor(WHITE_FONT_COLOR:GetRGBA())
+                    editBox:SetEnabled(true)
+                else
+                    editBox:SetTextColor(DISABLED_FONT_COLOR:GetRGBA())
+                    editBox:SetEnabled(false)
+                end
+                editBox.label:SetText(locale)
+                editBox.label:SetTextColor(hColor:GetRGBA())
+                editBox.label:SetWidth(LABEL_WIDTH)
+                if nextAnchor == options.patterns then
+                    editBox.label:SetPoint("TOPLEFT", nextAnchor, "TOPLEFT", 0, -2)
+                else
+                    editBox.label:SetPoint("TOPLEFT", nextAnchor, "BOTTOMLEFT", 0, -spacing)
+                end
+                local labelSpacing = 10
+                editBox:SetPoint("LEFT", editBox.label, "RIGHT", labelSpacing, 0);
+                editBox:SetScript("OnEnterPressed", function()
+                    dbEntry.tags[locale] = (editBox:GetText() or ""):lower()
+                    updateRelatedAddonData(true)
+                    editBox:ClearFocus()
+                    editBox:SetText(dbEntry.tags[locale])
+                end)
+                editBox:SetScript("OnEditFocusGained", function()
+                    options.directions:SetAlpha(0.75)
+                end)
+                local resetState = function()
+                    options.directions:SetAlpha(0)
+                    editBox:SetText(dbEntry.tags[locale] or "")
+                    editBox:ClearFocus()
+                end
+                editBox:SetScript("OnEscapePressed", resetState)
+                editBox:SetScript("OnEditFocusLost", resetState)
+                
+                --`.func` is defined as part of the ChatConfigBaseCheckButtonTemplate
+                -- its called in the "OnClick" handler
+                options.toggle.func = function(checkbox, isChecked)
+                    GroupBulletinBoardDBChar["FilterDungeon"..dbEntry.key] = isChecked
+                    local altCheckbox = getAlternateCheckbox(dbEntry.key)
+                    if altCheckbox then
+                        altCheckbox:SetChecked(isChecked)
+                    end
+                    self:UpdateFilterState(options, dbEntry)
+                end
+                
+                editBox:Show()
+                nextAnchor = editBox.label
+            end
+        end
+        options.sorts.up.func = function(_self)
+            moveSortPosition(dbEntry.key, "up")
+            Addon.UpdateAdditionalFiltersPanel(self.parent);
+        end
+        options.sorts.up:SetEnabled(dbEntry.sortIdx > 1)
+        options.sorts.down.func = function()
+            moveSortPosition(dbEntry.key, "down");
+            Addon.UpdateAdditionalFiltersPanel(self.parent);
+        end
+        options.delete:SetScript("OnClick", function()
+            StaticPopup_Show("GBB_DELETE_CATEGORY", dbEntry.name, nil, 
+                { key = dbEntry.key, panel = options:GetParent() }
+            );
+        end)
+        options:Layout()
+    end,
+    ReleaseAll = function(self) -- Hides all option entries and spacers
+        ---@cast self FilterSettingsPool
+        for _, container in pairs(self.entries) do
+            container:Hide()
+            container:ClearAllPoints()
+        end
+        for _, spacer in pairs(self.spacers) do         
+            spacer:Hide()
+            spacer:ClearAllPoints()
+        end
+    end,
+    AddSpacer = function(self, relativeTo) -- Spacers between individual filter options
+        local self = self ---@class FilterSettingsPool
+        local marginTop = 10
+        local total = #self.spacers
+        local initializeSpacer = function(spacer) ---@param spacer Texture
+            spacer:SetHeight(6)
+            spacer:SetPoint("TOPLEFT", relativeTo, "BOTTOMLEFT", 0, -marginTop)
+            spacer:SetWidth(self.parent:GetWidth())
+            spacer:Show()
+            return spacer
+        end
+        for i = 1, total do
+            local spacer = self.spacers[i]
+            if not spacer:IsShown() then
+                return initializeSpacer(spacer)
+            end
+        end
+        local new = self.parent:CreateTexture("$parentSpacer"..(total + 1), "BORDER")
+        new:SetTexture([[Interface\Common\UI-TooltipDivider]])
+        self.spacers[total + 1] = new
+        return initializeSpacer(new)
+    end,
+    CreateButton = function(self, parent) --- Create new filter button
+        local self = self ---@class FilterSettingsPool
+        local createBtn = self.create 
+            or CreateFrame("Button", "$parentCreateFilter", parent, "UIPanelButtonTemplate");
+        ---@cast createBtn UIPanelButtonTemplate
+        createBtn:SetText(CREATE)
+        createBtn:FitToText()
+        createBtn:SetScript("OnClick", function()
+            StaticPopup_Show("GBB_CREATE_CATEGORY", nil, nil, {panel = parent})
+        end)
+        self.create = createBtn
+        return createBtn
+    end,
+    PresetsButton = function(self, parent) -- Add presets button
+        local self = self ---@class FilterSettingsPool
+        local addPresetsBtn = self.addPresets 
+            or CreateFrame("Button", "$parentRestorePresets", parent, "UIPanelButtonTemplate");   
+        ---@cast addPresetsBtn UIPanelButtonTemplate
+        addPresetsBtn:SetText(DEFAULTS)
+        addPresetsBtn:FitToText()
+        addPresetsBtn:SetScript("OnClick", function()
+            local anyAdded = false
+            for key, preset in pairs(presets) do
+                local saved = GroupBulletinBoardDB.CustomFilters[key]
+                if saved and saved.isHidden ~= preset.isHidden then
+                    -- Dont reset here, the preset could be hidden because of game type like SoD, and we dont want-
+                    -- to reset any user modifications to the preset if they hit "reset" when logged into regular era. 
+                    -- Should have been reset if it was ever deleted, see StaticPopupDialogs["GBB_DELETE_CATEGORY"].
+                    saved.isHidden = preset.isHidden
+                    -- hack: to sort to top, make sure to call `fixSavedFiltersSorts`
+                    saved.sortIdx = 0 
+                    anyAdded = true
+                elseif not preset.isHidden then
+                    GroupBulletinBoardDB.CustomFilters[key] = CopyTable(preset)
+                    GroupBulletinBoardDB.CustomFilters[key].sortIdx = 0
+                    anyAdded = true
+                end
+            end
+            if anyAdded then
+                PlaySound(SOUNDKIT.IG_MAINMENU_OPEN)
+                updateRelatedAddonData()
+                fixSavedFiltersSorts()
+                Addon.UpdateAdditionalFiltersPanel(parent)
+            end
+        end)
+        self.addPresets = addPresetsBtn
+        return addPresetsBtn
+    end,
+    AddLegend = function(self, parent)
+        local self = self ---@class FilterSettingsPool
+        local legend = self.legend or parent:CreateFontString("$parentLegend", "OVERLAY", "GameFontNormalTiny")
+        -- "(*) Character Specific Settings"
+        legend:SetFormattedText("\40%s\41 %s", CHARACTER_SPECIFIC_SYMBOL, CHARACTER_SPECIFIC_SETTINGS) 
+        legend:Show()
+        self.legend = legend
+        return legend
+    end
+}
+---@param scrollPanel Frame Parent panel that the category settings will be drawn onto
+function Addon.UpdateAdditionalFiltersPanel(scrollPanel)
+    ---@cast Addon Addon_Options
+	local userFilters = GroupBulletinBoardDB.CustomFilters
+    local legend = FilterSettingsPool:AddLegend(scrollPanel)
+    legend:SetPoint("RIGHT", scrollPanel, "RIGHT", -20)
+    legend:SetPoint("TOP", scrollPanel, "TOP")
+    -- User Categories (sorted)
+    FilterSettingsPool:ReleaseAll()
+    local nextAnchor = scrollPanel ---@type Texture|Frame|Region
+	for idx, key in pairs(Addon:GetCustomFilterKeys()) do
+        local savedData = userFilters[key]
+        local filterSettings = FilterSettingsPool:AddFilterOptions(key, scrollPanel)
+        FilterSettingsPool:UpdateFilterState(filterSettings, savedData)
+        filterSettings:Show()
+        local spacer = FilterSettingsPool:AddSpacer(filterSettings)
+        if idx == 1 then
+            filterSettings:SetPoint("TOPLEFT", nextAnchor, "TOPLEFT", 0, -30)
+            scrollPanel:GetParent().ScrollBar.scrollStep 
+                = filterSettings:GetHeight() + spacer:GetHeight() + (select(5, spacer:GetPoint()) or 0);
+        else
+            filterSettings:SetPoint("TOPLEFT", nextAnchor, "BOTTOMLEFT", 0, -10)
+        end
+        nextAnchor = spacer
+	end
+
+	-- New Filter 
+    local createBtn = FilterSettingsPool:CreateButton(scrollPanel)
+    if nextAnchor then
+        createBtn:ClearAllPoints()
+        createBtn:SetPoint("TOPLEFT", nextAnchor, "BOTTOMLEFT", 0, -25)
+    end
+    FilterSettingsPool:PresetsButton(scrollPanel):SetPoint("LEFT", createBtn, "RIGHT", 10, 0)
 end

--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -761,8 +761,24 @@ if isClassicEra then
 	wotlkDungeonNames = {}
 end
 
-function GBB.GetDungeonSort()
-
+---@param additonalCategories (string[]|string[][])?
+function GBB.GetDungeonSort(additonalCategories)
+	if additonalCategories then
+		if additonalCategories[1]  
+		and type(additonalCategories[1]) == "table"
+		then -- flatten if 2d array provided
+			---@cast additonalCategories string[][]
+			local seen = {}
+			for _, categoryTable in ipairs(additonalCategories) do
+				for _, category in ipairs(categoryTable) do
+					seen[category] = true
+				end
+			end
+			additonalCategories = GetKeysArray(seen) --[[@as string[] ]]
+		end
+	else
+		additonalCategories = {} --[[@as string[] ]]
+	end
 	-- at some point we should probably move this to the /dungeons/cata.lua file
 	-- when i add support for the newly added holiday dungeons.
 	for eventName, eventData in pairs(GBB.Seasonal) do
@@ -775,7 +791,7 @@ function GBB.GetDungeonSort()
 
 	local dungeonOrder = { 
 		GBB.VanillaDungeonKeys, tbcDungeonNames, wotlkDungeonNames, cataDungeonKeys, 
-		pvpNames, GBB.Misc, debugNames
+		pvpNames, additonalCategories, GBB.Misc, debugNames
 	}
 
 	local vanillaDungeonSize = #GBB.VanillaDungeonKeys

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -1,4 +1,6 @@
-local TOCNAME,GBB=...
+local TOCNAME,
+	---@class Addon_GroupBulletinBoard : Addon_Localization, Addon_CustomFilters, Addon_Dungeons, Addon_Tags, Addon_Options
+	GBB = ...;
 
 GroupBulletinBoard_Addon=GBB
 
@@ -536,12 +538,23 @@ function GBB.Init()
 	GBB.DB.showminimapbutton=nil
 	GBB.DB.minimapPos=nil
 	
+	GBB.InitializeCustomFilters();
+	
 	-- Get localize and Dungeon-Information
 	GBB.L = GBB.LocalizationInit()	
 	GBB.dungeonNames = GBB.GetDungeonNames()
+	-- Add custom categories to `dungeonNames`
+	MergeTable(GBB.dungeonNames, GBB.GetCustomFilterNames());
+	-- add custom categories to levels table
+	MergeTable(GBB.dungeonLevel, GBB.GetAllCustomFilterLevels());
+	-- add custom categories to `dungeonSort` (adds internally)
+	local additionalCategories = GBB.GetCustomFilterKeys();
+	GBB.dungeonSort = GBB.GetDungeonSort(additionalCategories);
 	GBB.RaidList = GBB.GetRaids()
-	--GBB.dungeonLevel
-	GBB.dungeonSort = GBB.GetDungeonSort()	
+
+	-- Add tags for custom categories into `dungeonTagsLoc`. 
+	-- Must do before the call to `GBB.CreateTagList()` below
+	GBB.AddCustomFilterTags(GBB.dungeonTagsLoc);
 
 	-- Reset Request-List
 	GBB.RequestList={}

--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -13,6 +13,7 @@ Chat.lua
 Localization.lua
 dungeons/classic.lua
 dungeons/cata.lua
+CustomCategories.lua
 Dungeons.lua
 Tags.lua
 RequestList.lua

--- a/LFGBulletinBoard/LibGPIOptions.lua
+++ b/LFGBulletinBoard/LibGPIOptions.lua
@@ -1,6 +1,10 @@
-local TOCNAME,Addon = ...
-Addon.Options=Addon.Options or {}
-local Options=Addon.Options
+local TOCNAME,
+	---@class Addon_LibGPIOptions	
+	Addon = ...;
+
+---@class Lib_GPIOptions
+local Options = Addon.Options or {}
+Addon.Options = Options
 
 local function Options_CheckButtonRightClick(self,button)
 	if button=="RightButton" then

--- a/LFGBulletinBoard/Localization.lua
+++ b/LFGBulletinBoard/Localization.lua
@@ -204,6 +204,7 @@ GBB.locales = {
 		["AboutSlashCommand"]="<value> can be true, 1, enable, false, 0, disable. If <value> is omitted, the current status switches.",
 		["AboutInfo"]="GBB provides an overview of the endless requests in the chat channels. It detects all requests to the classic dungeons, sorts them and presents them clearly way. Numerous filtering options reduce the gigantic number to exactly the dungeons that interest you. And if that's not enough, GBB will let you know about any new request via a sound or chat notification. And finally, GBB can post your request repeatedly.",
 		["AboutCredits"]="Original by GPI / Erytheia-Razorfen",
+		["SAVE_ON_ENTER"] = ("Press \"%s\" to save changes."):format(KEY_ENTER),
 	},
 	deDE = {
 	["AboutInfo"] = "GBB verschafft euch den Überblick über die endlosen Anfragen in den Chat-Channels. Es erkennt alle Anfragen zu den klassischen Instanzen, sortiert sie und stellt sie übersichtlich da. Filtermöglichkeiten reduziert die gigantische Anzahl auf genau die Instanzen, die dich interessieren. Und falls das nicht reicht, informiert GBB dich über jede neue Anfrage mittels eines Sounds oder Chat-Benachrichtigung. Und abschließend kann GBB deine persönliche Anfrage wiederholt veröffentlichen.",
@@ -315,11 +316,13 @@ GBB.locales = {
 	["SlashDefault"] = "Hauptfenster öffnen",
 	["SlashReset"] = "Hauptfenster zurücksetzen",
 	["TabGroup"] = "Mitglieder",
-	["TabRequest"] = "Anfragen"
+	["TabRequest"] = "Anfragen",
+	["SAVE_ON_ENTER"] = ("Drücken Sie \"%s\", um die Änderungen zu speichern."):format(KEY_ENTER),
 	},
 	esMX = {
 		-- ["lfg_channel"]="BuscarGrupo", -- uses fallback
 		["world_channel"] = "Mundo",
+		["SAVE_ON_ENTER"] = ("Pulse \"%strings\" para guardar los cambios."):format(KEY_ENTER),
 	},
 	frFR = {
 	-- ["lfg_channel"]="RechercheGroupe", -- uses fallback
@@ -438,6 +441,7 @@ GBB.locales = {
 	["AboutSlashCommand"]="<value> peut être true, 1, enable, false, 0, disable. Si <value> est omise, l'état actuel commute.",
 	["AboutInfo"]="GBB fournit un aperçu des demandes sans fin dans les canaux de discussion. Il détecte toutes les demandes concernant les donjons classiques, les trie et les présente de manière claire. De nombreuses options de filtrage réduisent le nombre gigantesque à exactement les donjons qui vous intéressent. Et si cela ne suffit pas, GBB vous informe de toute nouvelle demande par une notification sonore ou par chat. Et enfin, GBB peut poster votre demande à plusieurs reprises",
 	["AboutCredits"]="Original par GPI / Erytheia-Razorfen",
+	["SAVE_ON_ENTER"] =("Appuyez sur « %s » pour enregistrer les modifications."),
 	},
 	ruRU = {
 		["AboutInfo"]="GBB обеспечивает группировку нескончаемых запросов в каналах чата. Он обнаруживает все сообщения про поиск группы в классические подземелья, сортирует и удобно представляет их. Многочисленные опции фильтрации уменьшают гигантское число сообщений и оставляют только те подземелья, которые вас интересуют. А если этого недостаточно, GBB сообщит вам о любом новом запросе через звуковое или чат-уведомление. И, наконец, GBB может публиковать ваш запрос повторно.",
@@ -547,6 +551,7 @@ GBB.locales = {
 		["SlashConfig"]="Открыть конфигурацию",
 		["SlashDefault"]="открыть главное окно",
 		["SlashReset"]="Сбросить положение главного окна",
+		["SAVE_ON_ENTER"] = ("Нажмите \"%s\", чтобы сохранить изменения."):format(KEY_ENTER),
 	},
 	zhTW = {
 		-- ["lfg_channel"]="尋求組隊", -- uses fallback
@@ -676,6 +681,7 @@ GBB.locales = {
 
 		["AboutInfo"]="GBB provides an overview of the endless requests in the chat channels. It detects all requests to the classic dungeons, sorts them and presents them clearly way. Numerous filtering options reduce the gigantic number to exactly the dungeons that interest you. And if that's not enough, GBB will let you know about any new request via a sound or chat notification. And finally, GBB can post your request repeatedly.",
 		["AboutCredits"]="Original by GPI / Erytheia-Razorfen",
+		["SAVE_ON_ENTER"] = ("按下「%s」以儲存變更。"):format(KEY_ENTER),
 	},
 	zhCN = {
 		-- ["lfg_channel"]="寻求组队", -- uses fallback
@@ -805,7 +811,11 @@ GBB.locales = {
 
 		["AboutInfo"]="GBB provides an overview of the endless requests in the chat channels. It detects all requests to the classic dungeons, sorts them and presents them clearly way. Numerous filtering options reduce the gigantic number to exactly the dungeons that interest you. And if that's not enough, GBB will let you know about any new request via a sound or chat notification. And finally, GBB can post your request repeatedly.",
 		["AboutCredits"]="Original by GPI / Erytheia-Razorfen",
+		["SAVE_ON_ENTER"] = ("按下\"%s\"以保存更改。"):format(KEY_ENTER),
 	},
+	ptBR = {
+		SAVE_ON_ENTER = ("Pressione \"%s\" para salvar as alterações."):format(KEY_ENTER)
+	}
 }
 GBB.locales.esES=GBB.locales.esMX
 GBB.locales.enUS=GBB.locales.enGB

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -402,6 +402,14 @@ function GBB.OptionsInit ()
 	GenerateExpansionPanel(GBB.Enum.Expansions.Classic)
 		
 	----------------------------------------------------------
+	-- Custom Filters/Categories
+	----------------------------------------------------------
+	local scrollChild = GBB.Options.AddPanel(ADDITIONAL_FILTERS, false, true);
+	scrollChild:SetWidth(
+		InterfaceOptionsFramePanelContainer:GetWidth() - scrollChild:GetParent().ScrollBar:GetWidth()
+	);
+	GBB.UpdateAdditionalFiltersPanel(scrollChild);
+	----------------------------------------------------------
 	-- Language Tags and Search Patterns
 	----------------------------------------------------------
 	GBB.Options.AddPanel(GBB.L["PanelTags"],false,true)

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -1,5 +1,5 @@
 local TOCNAME,
-	---@class Addon_Options : Addon_Localization
+	---@class Addon_Options : Addon_Localization, Addon_CustomFilters, Addon_Dungeons, Addon_Tags, Addon_LibGPIOptions
 	GBB= ...;
 local ChannelIDs
 local ChkBox_FilterDungeon
@@ -223,8 +223,21 @@ local function GenerateExpansionPanel(expansionID)
 	-- dont include misc filters in the "select all" buttons
 	local resetLimitIdx = #filters 
 
-	-- Misc Categories (only show for current xpac)
+	-- Extra Categories (only show for current xpac)
 	if isCurrentXpac then
+		
+		-- Add any Custom user filters 
+		local customCategories = GBB.GetCustomFilterKeys()
+		if next(customCategories) then
+			GBB.Options.Indent(-10)
+			GBB.Options.AddCategory(ADDITIONAL_FILTERS)
+			GBB.Options.Indent(10)
+			for _, key in ipairs(customCategories) do
+				tinsert(filters, CheckBoxFilter(key, false))
+			end
+		end
+
+		-- Add `GBB.Misc` defined categories
 		GBB.Options.Indent(-10)
 		GBB.Options.AddCategory(OTHER)
 		GBB.Options.Indent(10)		


### PR DESCRIPTION
**Related Issues**:
  - #179 
 
**Included in this PR**
- Support for user generated filters
- Settings panel for managing user generated filters
  - includes: a Toggle, ability to rename, filter sorting, filter pattern editing

**Notes**
I think this can be used for the SoD specific categories as well in #213, I've set it up so that we just have to include it as a preset.

I tried to use the old options library from the original author but it had far too many constraints for building a more dynamic settings panel. 

@Vysci, I Recommend we move towards using a library like AceConfig, it allows for an "easier" building of settings, but more importantly it does a good job at validating and maintaining state between options and their saved variable values. That would fix alot of the "requires reload" constraints around seeing settings changes go into effect. 

That ones a pretty big job tho. Admitably, this would have been a good first "module" to use the library for but ive already done
 the work of building out the frames by hand xD
 
**sample images**
![custom filter settings](https://i.imgur.com/V9qfkLm.png)