### PR TITLE
fix: Save options anytime they are closed or hidden

### DIFF
--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -170,7 +170,9 @@ end
 ---if the expansion is the current game client expansion, it will also include misc filters.
 ---@param expansionID ExpansionID
 local function GenerateExpansionPanel(expansionID)
-	GBB.Options.AddPanel(EXPANSION_FILTER_NAME[expansionID], false, true)
+	local panel = GBB.Options.AddPanel(EXPANSION_FILTER_NAME[expansionID], false, true)
+	-- hack: save changes anytime the panel is hidden (issues: 200, 147, 57)
+	panel:HookScript("OnHide", GBB.Options._DoOk)
 	
 	local isCurrentXpac = expansionID == PROJECT_EXPANSION_ID[WOW_PROJECT_ID];
 	local filters = {} ---@type CheckButton[]


### PR DESCRIPTION
Previously, most changed options would only save after clicking the "close" button specifically.
  - Tabbing between option categories now also saves changes.

**Note**: Still need to close/hide the options to see any changes on the bulletin board itself.