### PR TITLE
fix: move `GBB.Seasonal` dungeons into `/dungeons/cata.lua`

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -739,19 +739,10 @@ GBB.VanillaDungeonKeys = GBB.GetSortedDungeonKeys(
 );
 
 
--- used in Tags.lua for determining which tags are safe for game version
+-- table used in Tags.lua for determining which tags are safe for game version
 GBB.Misc = {
 	(isCata and "RDF" or nil), "MISC", "TRADE", "TRAVEL",
 	(isSoD and "INCUR" or nil)
-}
-
--- used to disable holiday specific filters when not in the correct date range
--- in FixFilters of Options.lua
-GBB.Seasonal = {
-    ["BREW"] = { startDate = "09/20", endDate = "10/06"},
-	["HOLLOW"] = { startDate = "10/18", endDate = "11/01"},
-	["LOVE"] = {startDate = "02/03", endDate = "02/17"},
-	["SUMMER"] = {startDate = "06/21", endDate = "07/05"},
 }
 
 -- clear unused dungeons in classic to not generate options/checkboxes with the-
@@ -779,16 +770,6 @@ function GBB.GetDungeonSort(additonalCategories)
 	else
 		additonalCategories = {} --[[@as string[] ]]
 	end
-	-- at some point we should probably move this to the /dungeons/cata.lua file
-	-- when i add support for the newly added holiday dungeons.
-	for eventName, eventData in pairs(GBB.Seasonal) do
-        if GBB.Tool.InDateRange(eventData.startDate, eventData.endDate) then
-			table.insert(cataDungeonKeys, 1, eventName)
-		else
-			table.insert(debugNames, 1, eventName)
-		end
-    end
-
 	local dungeonOrder = { 
 		GBB.VanillaDungeonKeys, tbcDungeonNames, wotlkDungeonNames, cataDungeonKeys, 
 		pvpNames, additonalCategories, GBB.Misc, debugNames

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -93,13 +93,7 @@ local function FixFilters()
 				end
 			end
 		end
-	end	
-
-	for eventName, eventData in pairs(GBB.Seasonal) do
-        if GBB.Tool.InDateRange(eventData.startDate, eventData.endDate) == false then
-			GBB.DBChar["FilterDungeon"..eventName]=false
-        end
-    end
+	end
 end
 
 local function ResetFilters()

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -624,7 +624,7 @@ local dungeonTags = {
 		zhTW = "波塔 波卡",
 		zhCN = "生态船",
 	},	
-	NULL = { -- The Crown Chemical Co. (Love is in the Air)
+	LOVE = { -- The Crown Chemical Co. (Love is in the Air)
 
 	},	
 	COS = { -- The Culling of Stratholme
@@ -659,7 +659,8 @@ local dungeonTags = {
 		zhTW = nil,
 		zhCN = "灵魂洪炉",
 	},	
-	NULL = { -- The Frost Lord Ahune (Midsummer)
+	SUMMER = { -- The Frost Lord Ahune (Midsummer)
+		enGB = "ahune",
 	},	
 	HOLLOW = { -- The Headless Horseman
 		enGB = "headless horseman hollow",


### PR DESCRIPTION
**Related Issues**:
- #253 

**In this PR**
- All the logic specific to seasonal dungeon events is now self contained and colocated in `/dungeons/cata.lua`.
- Adds `Tags.lua` entries for Midsummer and Valentines events.
- Decouple any seasonal dungeon stuff from classic era code