### PR TITLE
refactor: move `RDF` `BLOOD` and `INCUR` filters to `CustomCategories.lua`

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -111,8 +111,6 @@ function GBB.GetDungeonNames()
 		["BREW"] =  "Brewfest - Coren Direbrew",
 		["HOLLOW"] =  "Hallow's End - Headless Horseman",
     	["TRAVEL"] = "Travel services - Summons/Portals",
-		["BLOOD"] = "Bloodmoon",
-		["INCUR"] = "Incursions",
 		}
 
 	local dungeonNamesLocales={
@@ -623,7 +621,6 @@ function GBB.GetDungeonNames()
 	for _, key in ipairs(dungeonKeys) do
 		DefaultEnGB[key] = GBB.GetDungeonInfo(key).name or DefaultEnGB[key]
 	end
-	DefaultEnGB["RDF"] = LFG_TYPE_RANDOM_DUNGEON
 
 	setmetatable(dungeonNames, {__index = DefaultEnGB})
 
@@ -665,31 +662,18 @@ local tbcDungeonNames = GBB.GetSortedDungeonKeys(
 	{ GBB.Enum.DungeonType.Dungeon, GBB.Enum.DungeonType.Raid }
 );
 
-local pvpNames = GBB.GetSortedDungeonKeys(
-	-- not specificying an expansion id here-
-	-- gives **all** available dungeons **up to** current game xpac
-	nil,
-	GBB.Enum.DungeonType.Battleground
-);
+-- not specificying an expansion id gives **all** available dungeons **up to** current game xpac
+local pvpNames = GBB.GetSortedDungeonKeys(nil, GBB.Enum.DungeonType.Battleground);
 
--- hack: consider Bloodmoon event as a pvp event in config
-if isSoD then table.insert(pvpNames, "BLOOD") end
+local debugNames = {"DEBUG", "BAD", "NIL"}
 
-local debugNames = {
-	"DEBUG", "BAD", "NIL",
-}
-
-local raidNames = GBB.GetSortedDungeonKeys(
-	nil, -- all xpacs
-	GBB.Enum.DungeonType.Raid
-);
+local raidNames = GBB.GetSortedDungeonKeys(nil, GBB.Enum.DungeonType.Raid);
 
 -- Becasue theyre not actually dungeons and are not parsed by 
 -- `/data/dungeons/{version}.lua` we need to add them manually
 local miscCatergoriesLevels = {
-	["MISC"] =  {0,100}, ["TRAVEL"]={0,100}, ["INCUR"]={0,100},
-	["DEBUG"] = {0,100}, ["BAD"] =	{0,100}, ["TRADE"]=	{0,100},
-	["BLOOD"] = {0,100}, ["NIL"] = {0,100}, ["RDF"] = {0, 100},
+	["MISC"] = {0,100}, ["TRAVEL"] = {0,100}, ["DEBUG"] = {0,100},
+	["BAD"] = {0,100}, ["TRADE"] = {0,100}, ["NIL"] = {0,100},
 }
 
 -- Needed because Lua sucks, Blizzard switch to Python please
@@ -708,15 +692,6 @@ local function ConcatenateLists(Names)
 	end
 	return result, index
 end
-
-local function GetSize(list)
-	local size = 0
-	for _, _ in pairs(list) do
-		size = size + 1
-	end
-	return size
-end
-
 ----------------------------------------------
 -- Global functions/data
 ----------------------------------------------
@@ -740,10 +715,7 @@ GBB.VanillaDungeonKeys = GBB.GetSortedDungeonKeys(
 
 
 -- table used in Tags.lua for determining which tags are safe for game version
-GBB.Misc = {
-	(isCata and "RDF" or nil), "MISC", "TRADE", "TRAVEL",
-	(isSoD and "INCUR" or nil)
-}
+GBB.Misc = {"MISC", "TRADE", "TRAVEL"}
 
 -- clear unused dungeons in classic to not generate options/checkboxes with the-
 -- new data pipeline api these tables should already empty anyways when in classic client

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -1013,11 +1013,9 @@ local dungeonTags = {
 }
 dungeonTags["DEADMINES"] = { enGB = "dm" } -- should normalize "DM" to "DEADMINES" at somepoint.
 
---- Misc. Tags: 
--- id like to offload these to a seperate system at some point.
--- a more modular way of adding "categories" to the bulletin board
--- the tags and the key and the display name for the category would all be defined in the same place
-local otherTags = {
+--- Misc. categeories tags (these are core to the addon) 
+-- see `CustomCategories.lua` for additional user-editable categories/tags
+local miscTags = {
 	TRADE = { -- Trade Services
 	  enGB = "buy buying sell selling wts wtb hitem henchant htrade enchanter",
 	  deDE = "kaufe verkauf kauf verkaufe ah vk tg trinkgeld trinkgold vz schneider verzauberer verzaubere schliesskassetten schließkassetten kassetten schlossknacken schloßknacken alchimie",
@@ -1034,26 +1032,6 @@ local otherTags = {
 	  zhTW = nil,
 	  zhCN = nil,
 	},
-	BLOOD = isSoD and { -- Bloodmoon Event
-	  enGB = "blood bloodmoon bm",
-	  deDE = nil,
-	  ruRU = nil,
-	  frFR = nil,
-	  zhTW = nil,
-	  zhCN = nil,
-	} or nil,
-	INCUR = isSoD and { -- Incursion Event
-	  enGB = "inc incur incursion incursions incurusions loops",
-	  deDE = nil,
-	  ruRU = nil,
-	  frFR = nil,
-	  zhTW = nil,
-	  zhCN = nil,
-	} or nil,
-	--- Random Dungeon Finder
-	RDF = not isClassicEra and {
-	  enGB = "rdf random dungeons spam heroics",
-	} or nil
 }
 
 --- Secondary Dungeon Tags: related to identifying dungeon or activity name from a message.
@@ -1069,7 +1047,7 @@ local dungeonSecondTags = {
 -- Comaptibility reformatting of data back to original shape.
 -- [locale] => [dungeonKey]=> Array<tag>
 local dungeonTagsLoc = {}
-for _, categoryTags in pairs({dungeonTags, otherTags}) do
+for _, categoryTags in pairs({dungeonTags, miscTags}) do
 	for dungeonKey, tagsByLocale in pairs(categoryTags) do
 		tagsByLocale = langSplit(tagsByLocale)
 		for locale, tags in pairs(tagsByLocale) do
@@ -1106,7 +1084,7 @@ for locale, dungeonTags in pairs(GBB.dungeonTagsLoc) do
 	for dungeonKey, _ in pairs(dungeonTags) do
 		if not (validGameVersionKeys[dungeonKey] 
 			or GBB.dungeonSecondTags[dungeonKey]
-			or otherTags[dungeonKey])
+			or miscTags[dungeonKey])
 		then
 			GBB.dungeonTagsLoc[locale][dungeonKey] = nil
 		end


### PR DESCRIPTION
These changes are related to the feature added in #250. Users can now edit the client specific filters, `RDF`,`BLOOD`,and `INCUR`, without having to edit the main lua file. Useful for users on non english locales.

Fixes: 
 - added "gammas" as part of RDF english tags (#193)
  - the "Defaults"/restore preset button no longer overrides custom search patterns.
  - Pressing "escape" now properly closes custom filter related popup menus