### PR TITLE
hotfix: improve Tot4W tags, update `.toc` and `changelog.txt`

### DIFF
--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -1,7 +1,7 @@
 ## Interface: 11502, 40400
 ## Title: LFG Bulletin Board
 ## Notes: Sort LFG/LFM Messages
-## Version: 3.31
+## Version: 3.32
 ## Author: Vyscî-Whitemane
 ## DefaultState: enabled
 ## SavedVariables: GroupBulletinBoardDB

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -738,10 +738,10 @@ local dungeonTags = {
 		zhCN = nil,
 	},
 	TOFW = { -- Throne of the Four Winds
-		enGB = "totfw toftw tofw four winds tofw10 tofw25",
-		deDE = nil,
+		enGB = "totfw toftw tofw four winds tofw10 tofw25 tot4w to4w t4w",
+		deDE = "td4w t4w",
 		ruRU = nil,
-		frFR = nil,
+		frFR = "t4v t4w",
 		zhTW = nil,
 		zhCN = nil,
 	},	

--- a/LFGBulletinBoard/changelog.txt
+++ b/LFGBulletinBoard/changelog.txt
@@ -1,4 +1,14 @@
 Group Bulletin Board
+3.32
+ - New! Support added for user created filters. See "Additional Filters" category in the addons settings.
+   - The filters for "Random Dungeon", "Incursions", and "Bloodmoon" have been moved here as editable presets.
+ - Existing dungeon filter settings will now save any time the settings panel is hidden. Used to only save after pressing the "close" button.
+ - Fixed a breaking issue related to seasonal Midsummer event.
+ - "Throne of the Four Winds" tags updates.
+   - english: `to4w`, `t4w`, `tot4w`.
+   - french: `t4v`, `t4w`.
+   - german: `td4w`, `t4w`.
+   
 3.31
  - Fixed issue of joining the wrong "LookingForGroup" channel in Cataclysm `frFR` and `esES` clients.
  - Fixed issue where *new characters* would join "LookingForGroup" as their `/1`. 


### PR DESCRIPTION
Doc updates in prep for 3.32.
 
 **Tot4W tags hotfix adds**:   
   - english: `to4w`, `t4w`, `tot4w`.
   - french: `t4v`, `t4w`.
   - german: `td4w`, `t4w`.