### PR TITLE
Fixing CustomFilters errors

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -526,6 +526,7 @@ function GBB.Init()
 	if not GBB.DB.CustomLocalesDungeon then GBB.DB.CustomLocalesDungeon={} end
 	if not GBB.DB.FontSize then GBB.DB.FontSize = "GameFontNormal" end
 	if not GBB.DB.DisplayLFG then GBB.DB.DisplayLFG = false end
+	if not GBB.DB.CustomFilters then GBB.DB.CustomFilters = {} end
 	GBB.DB.Server=nil -- old settings
 	
 	if GBB.DB.OnDebug == nil then GBB.DB.OnDebug=false end


### PR DESCRIPTION
Fixing lua errors that occur in the case CustomFilters hasn't been initialized.