### PR TITLE
minor: move `CustomFilters` saved var initialization to `CustomCategories.lua`

### DIFF
--- a/LFGBulletinBoard/CustomCategories.lua
+++ b/LFGBulletinBoard/CustomCategories.lua
@@ -91,6 +91,7 @@ local presets = {
 
 function Addon.InitializeCustomFilters()
     assert(GroupBulletinBoardDB, "`GroupBulletinBoardDB` not found in `InitializeCustomFilters()`. Initialize *after* ADDON_LOADED event")
+    if not GroupBulletinBoardDB.CustomFilters then GroupBulletinBoardDB.CustomFilters = {} end
     for key, preset in pairs(presets) do
         local stored = GroupBulletinBoardDB.CustomFilters[key]
         -- hide any saved presets that are disabled for current client

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -526,7 +526,6 @@ function GBB.Init()
 	if not GBB.DB.CustomLocalesDungeon then GBB.DB.CustomLocalesDungeon={} end
 	if not GBB.DB.FontSize then GBB.DB.FontSize = "GameFontNormal" end
 	if not GBB.DB.DisplayLFG then GBB.DB.DisplayLFG = false end
-	if not GBB.DB.CustomFilters then GBB.DB.CustomFilters = {} end
 	GBB.DB.Server=nil -- old settings
 	
 	if GBB.DB.OnDebug == nil then GBB.DB.OnDebug=false end


### PR DESCRIPTION
In attempts to keep any non "read" action to saved variables pertaining to custom filters local to its "module's" file

Context:
- #258
- #259