### PR TITLE
bugfix: "Additional Filters" ui bug on first load

### DIFF
--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -398,11 +398,11 @@ function GBB.OptionsInit ()
 	----------------------------------------------------------
 	-- Custom Filters/Categories
 	----------------------------------------------------------
-	local scrollChild = GBB.Options.AddPanel(ADDITIONAL_FILTERS, false, true);
-	scrollChild:SetWidth(
-		InterfaceOptionsFramePanelContainer:GetWidth() - scrollChild:GetParent().ScrollBar:GetWidth()
+	local customCategoriesFrame = GBB.Options.AddPanel(ADDITIONAL_FILTERS, false, true);
+	customCategoriesFrame:SetWidth(
+		InterfaceOptionsFramePanelContainer:GetWidth() - customCategoriesFrame:GetParent().ScrollBar:GetWidth()
 	);
-	GBB.UpdateAdditionalFiltersPanel(scrollChild);
+	-- defer Update call until after language "Tags" saved vars are initialized bellow
 	----------------------------------------------------------
 	-- Language Tags and Search Patterns
 	----------------------------------------------------------
@@ -447,6 +447,7 @@ function GBB.OptionsInit ()
 	CreateEditBoxDungeon("DEADMINES","",445,200)
 	GBB.Options.Indent(-10)
 
+	GBB.UpdateAdditionalFiltersPanel(customCategoriesFrame); -- update the custom filters panel now.
 	----------------------------------------------------------	
 	-- localization
 	----------------------------------------------------------


### PR DESCRIPTION
Encountered after deleting my saved vars file testing #258. Very minor issue only likely encountered by new users with no saved vars at all.

- Issue was caused by the `TagsEnglish`, `TagsGerman`, etc. saved var values not having been initialized before first call to `GBB.UpdateAdditionalFiltersPanel()` causing the following snippet to always return `nil` and the corresponding editboxes not being shown. 
```lua
local isLocaleUserEnabled = function(locale)
    local enabledLocales = {
        enGB = GroupBulletinBoardDB.TagsEnglish,
        enUS = GroupBulletinBoardDB.TagsEnglish,
        deDE = GroupBulletinBoardDB.TagsGerman,
        ruRU = GroupBulletinBoardDB.TagsRussian,
        frFR = GroupBulletinBoardDB.TagsFrench,
        zhTW = GroupBulletinBoardDB.TagsZhtw,
        zhCN = GroupBulletinBoardDB.TagsZhcn,
        esES = GroupBulletinBoardDB.TagsSpanish,
        esMX = GroupBulletinBoardDB.TagsSpanish,
        ptBR = GroupBulletinBoardDB.TagsPortuguese,
    }
    return enabledLocales[locale]
end
```

Just deferred the call to `UpdateAditionalFiltersPanel` in preference to moving the whole "Additional Filters" section below the "Search Patterns" section.

**Image of bug**
![image](https://github.com/Vysci/LFG-Bulletin-Board/assets/20932280/fbc8a295-648d-43c0-ab70-74788a696d98)
