### PR TITLE
fix: lua errors for missing tags after deleting a custom category

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -554,7 +554,7 @@ function GBB.Init()
 
 	-- Add tags for custom categories into `dungeonTagsLoc`. 
 	-- Must do before the call to `GBB.CreateTagList()` below
-	GBB.AddCustomFilterTags(GBB.dungeonTagsLoc);
+	GBB.SyncCustomFilterTags(GBB.dungeonTagsLoc);
 
 	-- Reset Request-List
 	GBB.RequestList={}


### PR DESCRIPTION
Related Issues:
- #262

Reworked `AddCustomFilterTags` to `SyncCustomFilterTags` which now removes tags for any deleted custom filter keys and adds any enabled custom filter's tags as well.
