### PR TITLE
fix: indexing undefined global in `Event_CHAT_MSG_SYSTEM` event handler

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -1,5 +1,5 @@
 local TOCNAME,
-	---@class Addon_GroupBulletinBoard : Addon_Localization, Addon_CustomFilters, Addon_Dungeons, Addon_Tags, Addon_Options
+	---@class Addon_GroupBulletinBoard : Addon_Localization, Addon_CustomFilters, Addon_Dungeons, Addon_Tags, Addon_Options, Addon_Tool
 	GBB = ...;
 
 GroupBulletinBoard_Addon=GBB
@@ -820,10 +820,9 @@ local function Event_CHAT_MSG_SYSTEM(arg1)
 		
 		if info~="" then
 			local txt
-			
 			if class and class~="" then 
 				txt="|Hplayer:"..name.."|h"
-					..(GBB.Tool.GetClassIcon(req.class) or "")
+					..(GBB.Tool.GetClassIcon(class) or "")
 					.."|c"..GBB.Tool.ClassColor[class].colorStr .. name.."|r"
 					..symbol.."|h";
 			else

--- a/LFGBulletinBoard/LibGPIToolBox.lua
+++ b/LFGBulletinBoard/LibGPIToolBox.lua
@@ -1,8 +1,10 @@
 local TOCNAME,
 	---@class Addon_Tool	
 	Addon = ...;
-Addon.Tool=Addon.Tool or {}
-local Tool=Addon.Tool
+
+---@class ToolBox
+local Tool = {}
+Addon.Tool = Tool
 
 Tool.IconClassTexture="Interface\\GLUES\\CHARACTERCREATE\\UI-CHARACTERCREATE-CLASSES"
 Tool.IconClassTextureWithoutBorder="Interface\\WorldStateFrame\\ICONS-CLASSES"

--- a/LFGBulletinBoard/changelog.txt
+++ b/LFGBulletinBoard/changelog.txt
@@ -4,6 +4,7 @@ Group Bulletin Board
    - The filters for "Random Dungeon", "Incursions", and "Bloodmoon" have been moved here as editable presets.
  - Existing dungeon filter settings will now save any time the settings panel is hidden. Used to only save after pressing the "close" button.
  - Fixed a breaking issue related to seasonal Midsummer event.
+ - Fixed lua error related to Friends/Guild members login notification feature.
  - "Throne of the Four Winds" tags updates.
    - english: `to4w`, `t4w`, `tot4w`.
    - french: `t4v`, `t4w`.


### PR DESCRIPTION
Related Issue:
- #264

Added some additional LuaLS type annotations to cover the case that missed the initial bug.