### PR TITLE
chore: `.toc` game version update

### DIFF
--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -1,4 +1,4 @@
-## Interface: 11502, 40400
+## Interface: 11503, 40400
 ## Title: LFG Bulletin Board
 ## Notes: Sort LFG/LFM Messages
 ## Version: 3.32

--- a/LFGBulletinBoard/changelog.txt
+++ b/LFGBulletinBoard/changelog.txt
@@ -2,9 +2,10 @@ Group Bulletin Board
 3.32
  - New! Support added for user created filters. See "Additional Filters" category in the addons settings.
    - The filters for "Random Dungeon", "Incursions", and "Bloodmoon" have been moved here as editable presets.
- - Existing dungeon filter settings will now save any time the settings panel is hidden. Used to only save after pressing the "close" button.
- - Fixed a breaking issue related to seasonal Midsummer event.
- - Fixed lua error related to Friends/Guild members login notification feature.
+ - Fixed:
+   - Existing dungeon *checkbox* filters will now save any time the settings are hidden. Used to only save after pressing the "close" button.
+   - Breaking issue related to seasonal events.
+   - lua error related to Friends/Guild members login notification feature.
  - "Throne of the Four Winds" tags updates.
    - english: `to4w`, `t4w`, `tot4w`.
    - french: `t4v`, `t4w`.


### PR DESCRIPTION
toc interface version bump for new client: 1.15.2 -> 1.15.3
Also minor changelog entry styling for 3.32 release