### PR TITLE
refactor: move from blizzard deprecated `InterfaceOptions_AddCategory` to `Settings.RegisterCanvasLayoutCategory` 

### DIFF
--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -124,11 +124,7 @@ local function createMenu(DungeonID,req)
 	GBB.PopupDynamic:AddItem(GBB.L["CboxNotifyChat"],false,GBB.DB,"NotifyChat")
 	GBB.PopupDynamic:AddItem(GBB.L["CboxRemoveRealm"],false,GBB.DB,"RemoveRealm")
 	GBB.PopupDynamic:AddItem("",true)
-	GBB.PopupDynamic:AddItem(GBB.L["HeaderSettings"],false, GBB.OptionsBuilder.OpenCategoryPanel, 1)
-
-	GBB.PopupDynamic:AddItem(GBB.L["PanelFilter"], false, GBB.OptionsBuilder.OpenCategoryPanel, 2)
-
-	GBB.PopupDynamic:AddItem(GBB.L["PanelAbout"], false, GBB.OptionsBuilder.OpenCategoryPanel, 3)
+	GBB.PopupDynamic:AddItem(SETTINGS, false, GBB.OptionsBuilder.OpenCategoryPanel, 1)
 	GBB.PopupDynamic:AddItem(GBB.L["BtnCancel"],false)
 	GBB.PopupDynamic:Show()
 end

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -166,7 +166,7 @@ end
 local function GenerateExpansionPanel(expansionID)
 	local panel = GBB.OptionsBuilder.AddNewCategoryPanel(EXPANSION_FILTER_NAME[expansionID], false, true)
 	-- hack: save changes anytime the panel is hidden (issues: 200, 147, 57)
-	panel:HookScript("OnHide", GBB.OptionsBuilder._DoOk)
+	panel:HookScript("OnHide", GBB.OptionsBuilder.onCommit)
 	
 	local isCurrentXpac = expansionID == PROJECT_EXPANSION_ID[WOW_PROJECT_ID];
 	local filters = {} ---@type CheckButton[]
@@ -273,12 +273,12 @@ end
 
 function GBB.OptionsInit ()
 	GBB.OptionsBuilder.Init(
-		function() -- ok button			
-			GBB.OptionsBuilder.DoOk() 
+		function(panelFrame) -- called when "close" button is pressed	
+			GBB.OptionsBuilder.DoOk() -- saves any widget states to the DB
 			if GBB.DB.TimeOut< 60 then GBB.DB.TimeOut = 60 end
 			GBB.OptionsUpdate()	
 		end,
-		function() -- Chancel/init button
+		function(panelFrame) -- called whenever the canvas view is refreshed (swapping categories, on open, etc.)
 			local t= GBB.PhraseChannelList(GetChannelList())
 			for i=1,20 do
 				if i<20 then 
@@ -287,14 +287,13 @@ function GBB.OptionsInit ()
 					_G[ChannelIDs[i]:GetName().."Text"]:SetText((t[i] and t[i].name or ""))
 				end
 			end
-			GBB.OptionsBuilder.DoCancel() 
+			GBB.OptionsBuilder.DoRefresh() -- syncs widgets to DB state
 		end, 
-		function() -- default button
-			GBB.OptionsBuilder.DoDefault()
+		function(panelFrame) -- called when the default button is pressed (not implemented for addon panels)
+			GBB.OptionsBuilder.DoDefault() -- reset widgets to default state.
 			GBB.DB.MinimapButton.position=40			
 			GBB.ResetWindow()		
 			GBB.OptionsUpdate()	
-			
 		end
 		)
 	

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -971,11 +971,7 @@ local function createMenu(DungeonID,req)
 	GBB.PopupDynamic:AddItem(GBB.L["CboxRemoveRealm"],false,GBB.DB,"RemoveRealm")
 	GBB.PopupDynamic:AddItem(GBB.L["CboxNotifyChat"],false,GBB.DB,"NotifyChat")
 	GBB.PopupDynamic:AddItem("",true)
-	GBB.PopupDynamic:AddItem(GBB.L["HeaderSettings"],false, GBB.OptionsBuilder.OpenCategoryPanel, 1)
-
-	GBB.PopupDynamic:AddItem(GBB.L["PanelFilter"], false, GBB.OptionsBuilder.OpenCategoryPanel, 2)
-
-	GBB.PopupDynamic:AddItem(GBB.L["PanelAbout"], false, GBB.OptionsBuilder.OpenCategoryPanel, 3)
+	GBB.PopupDynamic:AddItem(SETTINGS, false, GBB.OptionsBuilder.OpenCategoryPanel, 1)
 	GBB.PopupDynamic:AddItem(GBB.L["BtnCancel"],false)
 	GBB.PopupDynamic:Show()
 end


### PR DESCRIPTION
**In this PR**:
- Re-implemented the `InterfaceOptions_AddCategory` function locally for when the deprecated code is eventually removed from blizzard source.
- Removed some ui elements that would previously open to specific panels.

**Notes:** 
- Blizzard moved to the 10.0 UI in classic clients last year and the `OpenToCategory` method no longer opens to subcategories. See https://github.com/Stanzilla/WoWUIBugs/issues/285
- The addon up to this point previously "OnCancel", "OnOkay" and "OnDefault" functions for updating the settings panels but blizzard now uses a scheme with "OnCommit"/"OnRefresh"/"OnDefault"


    