### PR TITLE
refactor: migrate `CheckButton` options widgets to use `SavedVarRegistry`

### DIFF
--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -136,7 +136,11 @@ end
 
 local DoSelectFilter=function(state, ChkBox, Start, Max)
 	for index=Start,Max do ---trade -misc
-		ChkBox[index]:SetChecked(state)
+		if ChkBox[index].SetSavedValue then -- new api for managing saved vars. 
+			ChkBox[index]:SetSavedValue(state)
+		else
+			ChkBox[index]:SetChecked(state)
+		end
 	end	
 end
 	


### PR DESCRIPTION
**In this PR**:
- Checkbox filters now save without having to `close` the options panel.
  - The `.func` field from `ChatConfigCheckButtonTemplate` is used to trigger the savedVar handle's OnChange callbacks
- shift+right click will now reset a checkbox back to its default value

**Related Issues**:
 - resolves #57
 - resolves #147


**Images**:
![live example](https://i.imgur.com/IaA46TN.gif)

![live example2](https://i.imgur.com/BnYmoBU.gif)