### PR TITLE
refactor: migrate `DropDownMenu` to utilize `SavedVarRegistry`

### DIFF
--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -325,7 +325,7 @@ function GBB.OptionsInit ()
 	CheckBox("OrderNewTop",true)
 	CheckBox("HeadersStartFolded",false)
 	GBB.OptionsBuilder.AddSpacerToPanel()
-	GBB.OptionsBuilder.AddTextToCurrentPanel(GBB.L["msgFontSize"],-20)
+	GBB.OptionsBuilder.AddTextToCurrentPanel(FONT_SIZE, -20)
 	GBB.OptionsBuilder.AddDropdownToCurrentPanel(GBB.DB,"FontSize", "GameFontNormal", {"GameFontNormalSmall", "GameFontNormal", "GameFontNormalLarge"}) 
 
 	CheckBox("CombineSubDungeons",false)


### PR DESCRIPTION
**In this PR**:
I've modified the input for the list that can be passed to `AddDropdownToCurrentFrame`.
It now accept a table with button info directly for being able to display different text than what the inner button `.value` should be.
- Removed "reload required" text from font size setting

**Images**:
![font size example](https://i.imgur.com/Rvp9Z51.gif)