### PR TITLE
refactor: post rework cleanup of `LibGPIOptions.lua`

### DIFF
--- a/LFGBulletinBoard/LibGPIOptions.lua
+++ b/LFGBulletinBoard/LibGPIOptions.lua
@@ -182,114 +182,20 @@ function Options.Init(onCommit,onRefresh,onDefault)
 	Options.onDefault=onDefault
 	Options.CategoryPanels={}
 	Options.Frames={}
-	Options.CheckBoxes={}
-	Options.Color={}
-	Options.Buttons={}
-	Options.EditBoxes={}
-	Options.Vars={} -- any saved variable tables postfixed with _db
-	Options.Index={}
 	Options.Frames.count=0
 	Options.scale=1
 end
-		
-function Options.DoOk() -- Hooked to the `OnCommit` handler, called when the `close` button is pressed.
-	-- Done with RegisterFrameWithSavedVar now
-	-- for name, cbox in pairs(Options.CheckBoxes) do
-	-- 	if Options.Vars[name .. "_db"]~=nil and Options.Vars[name]~=nil then
-	-- 		Options.Vars[name .. "_db"] [Options.Vars[name]] = cbox:GetChecked()
-	-- 	end
-	-- end
 
-	-- for name,color in pairs(Options.Color) do
-	-- 	if Options.Vars[name .. "_db"]~=nil and Options.Vars[name]~=nil then
-	-- 		Options.Vars[name .. "_db"] [Options.Vars[name]].r=color.ColR
-	-- 		Options.Vars[name .. "_db"] [Options.Vars[name]].g=color.ColG
-	-- 		Options.Vars[name .. "_db"] [Options.Vars[name]].b=color.ColB
-	-- 		Options.Vars[name .. "_db"] [Options.Vars[name]].a=color.ColA
-	-- 	end
-	-- end	
-	
-	-- for name,edit in pairs(Options.EditBoxes) do
-	-- 	if Options.Vars[name .. "_onlynumbers"] then 
-	-- 		Options.Vars[name .. "_db"][Options.Vars[name]] = edit:GetNumber()
-	-- 	else
-	-- 		if Options.Vars[name.."_suggestion"] and Options.Vars[name.."_suggestion"]~="" then
-	-- 			if edit:GetText()==Options.Vars[name.."_suggestion"] then
-	-- 				Options.Vars[name .. "_db"] [Options.Vars[name]] = ""
-	-- 			else
-	-- 				Options.Vars[name .. "_db"] [Options.Vars[name]] = edit:GetText()
-	-- 			end
-	-- 		else
-	-- 			Options.Vars[name .. "_db"] [Options.Vars[name]] = edit:GetText()
-	-- 		end
-	-- 	end
-	-- end
-end
-
--- `OnCancel` function has been deprecated by blizzard, most changes are committed immediately now.
--- `OnRefresh` is called every time the canvas view is refreshed (swapping categories, opening, etc.)
--- `DoRefresh` is hooked into the `OnRefresh` event in `Options.lua` setup.
-function Options.DoRefresh()
-	-- for name,cbox in pairs(Options.CheckBoxes) do 
-	-- 	if Options.Vars[name .. "_db"]~=nil and Options.Vars[name]~=nil then
-	-- 		cbox:SetChecked( Options.Vars[name .. "_db"] [Options.Vars[name]] )
-	-- 	end
-	-- end
-	
-	-- for name,color in pairs(Options.Color) do
-	-- 	if Options.Vars[name .. "_db"]~=nil and Options.Vars[name]~=nil then
-	-- 		color:GetNormalTexture():SetVertexColor(
-	-- 			Options.Vars[name .. "_db"] [Options.Vars[name]].r,
-	-- 			Options.Vars[name .. "_db"] [Options.Vars[name]].g,
-	-- 			Options.Vars[name .. "_db"] [Options.Vars[name]].b,
-	-- 			Options.Vars[name .. "_db"] [Options.Vars[name]].a
-	-- 		)
-	-- 		color.ColR,color.ColG,color.ColB,color.ColA=Options.Vars[name .. "_db"] [Options.Vars[name]].r, Options.Vars[name .. "_db"] [Options.Vars[name]].g,	Options.Vars[name .. "_db"] [Options.Vars[name]].b,	Options.Vars[name .. "_db"] [Options.Vars[name]].a
-	-- 	end
-	-- end
-	
-	-- for name,edit in pairs(Options.EditBoxes) do
-	-- 	if Options.Vars[name .. "_onlynumbers"] then 
-	-- 		edit:SetNumber( Options.Vars[name .. "_db"] [Options.Vars[name]] )
-	-- 	else
-	-- 		edit:SetText( Options.Vars[name .. "_db"] [Options.Vars[name]] )
-	-- 		EditBox_OnFocusLost(edit)
-	-- 	end		
-	-- end
-end
-	
--- Hooked to the `OnDefault` handler, called when the `default` button is pressed. 
-function Options.DoDefault() -- note: default button does not exist for addons anymore, has to be implemented.
-	-- for name,cbox in pairs(Options.CheckBoxes) do
-	-- 	if Options.Vars[name .. "_db"]~=nil and Options.Vars[name]~=nil then
-	-- 		Options.Vars[name .. "_db"] [Options.Vars[name]]= Options.Vars[name .. "_init"]
-	-- 	end
-	-- end
-
-	-- for name,color in pairs(Options.Color) do
-	-- 	if Options.Vars[name .. "_db"]~=nil and Options.Vars[name]~=nil then
-	-- 		Options.Vars[name .. "_db"] [Options.Vars[name]].r = Options.Vars[name .. "_init"].r
-	-- 		Options.Vars[name .. "_db"] [Options.Vars[name]].g = Options.Vars[name .. "_init"].g
-	-- 		Options.Vars[name .. "_db"] [Options.Vars[name]].b = Options.Vars[name .. "_init"].b
-	-- 		Options.Vars[name .. "_db"] [Options.Vars[name]].a = Options.Vars[name .. "_init"].a
-
-	-- 	end
-	-- end
-	
-	-- for name,edit in pairs(Options.EditBoxes) do
-	-- 	Options.Vars[name .. "_db"] [Options.Vars[name]]= Options.Vars[name .. "_init"]
-	-- end
-	for _, savedVars in pairs(SavedVarRegistry.tracked) do -- will handle any registered saved variables
+-- Sets all saved variables registered to any widgets to their default values. 
+function Options.DefaultRegisteredVariables() 
+	for _, savedVars in pairs(SavedVarRegistry.tracked) do
 		for _, handle in pairs(savedVars) do
 			handle:SetToDefault()
 		end
 	end
-	Options:DoRefresh()
 end
 	
-function Options.SetScale(x)
-	Options.scale=x
-end
+function Options.SetScale(x) Options.scale = x; end
 
 ---Creates a new settings category and returns its display frame.
 ---@param title string
@@ -301,6 +207,7 @@ function Options.AddNewCategoryPanel(title, noHeader, scrollable)
 	local frameName = Options.Prefix.."Category"..categoryIdx
 	---@class SettingsCategoryPanel: Frame
 	local panelFrame = CreateFrame("Frame", frameName, UIParent)
+
 	Options.CategoryPanels[categoryIdx] = panelFrame
 	Options.CurrentPanel = panelFrame
 	panelFrame.name = title
@@ -344,7 +251,7 @@ function Options.Indent(width)
 	if width==nil then width=10 end
 	Options.NextRelativX = Options.NextRelativX + width
 end
-	
+
 function Options.InLine()
 	Options.inLine=true
 	Options.LineRelativ=nil
@@ -361,69 +268,61 @@ function Options.SetRightSide(width)
 	Options.NextRelativX= (width or 310) / Options.scale
 	Options.NextRelativY=0
 end
-	
+
+---@param version string	
 function Options.AddVersion(version)
-	local i="version_"..#Options.CategoryPanels
-	Options.Frames[i] = Options.CurrentPanel:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-	Options.Frames[i]:SetText(version)
-	Options.Frames[i]:SetPoint("BOTTOMRIGHT", -10, 10)
-	Options.Frames[i]:SetFont("Fonts\\FRIZQT__.TTF", 12)
-	return Options.Frames[i]
+	local versionText = Options.CurrentPanel:CreateFontString(Options.Prefix.."VersionText", "OVERLAY", "GameFontNormal")
+	versionText:SetText(version)
+	versionText:SetPoint("BOTTOMRIGHT", -10, 10)
+	versionText:SetFont("Fonts\\FRIZQT__.TTF", 12)
+	return versionText
 end
 
 ---@param text string
 ---@return FontString
 function Options.AddHeaderToCurrentPanel(text)
-	local c=Options.Frames.count+1
-	Options.Frames.count=c		
-	local CatName=Options.Prefix .. "Cat" .. c
-	Options.Frames[CatName] = Options.CurrentPanel:CreateFontString(CatName, "OVERLAY", "GameFontNormal")
-	Options.Frames[CatName]:SetText('|cffffffff' .. text .. '|r')
-	Options.Frames[CatName]:SetPoint("TOPLEFT",Options.NextRelativ,"BOTTOMLEFT", Options.NextRelativX, Options.NextRelativY-10)
-	Options.Frames[CatName]:SetFontObject("GameFontNormalLarge")
-	Options.Frames[CatName]:SetScale(Options.scale)
-	Options.NextRelativ=CatName
+	local frameIdx=Options.Frames.count+1
+	Options.Frames.count=frameIdx		
+	local headerName=Options.Prefix .. "Header" .. frameIdx
+	local header = Options.CurrentPanel:CreateFontString(headerName, "OVERLAY", "GameFontNormal")
+	header:SetText(text)
+	header:SetTextColor(1,1,1,1)
+	header:SetPoint("TOPLEFT",Options.NextRelativ,"BOTTOMLEFT", Options.NextRelativX, Options.NextRelativY-10)
+	header:SetFontObject("GameFontNormalLarge")
+	header:SetScale(Options.scale)
+	Options.Frames[headerName] = header
+	Options.NextRelativ=headerName
 	Options.NextRelativX=0
 	Options.NextRelativY=0
-	return Options.Frames[CatName]
-end
-
----@param header FontString
----@param text string
-function Options.EditHeaderText(header, text)
-	local c=Options.Frames.count+1
-	header:SetText('|cffffffff' .. text .. '|r')	
+	return header
 end
 
 ---@param text string
 ---@param onClick fun()?
 ---@return Button
 function Options.AddButtonToCurrentPanel(text, onClick)
-	local c=Options.Frames.count+1
-	Options.Frames.count=c	
-	local ButtonName=Options.Prefix .."BUTTON_"..c
-			
-	Options.Buttons[ButtonName] = CreateFrame("Button", ButtonName, Options.CurrentPanel, "UIPanelButtonTemplate")
-	Options.Buttons[ButtonName]:ClearAllPoints()
-	
-	if Options.inLine~=true or Options.LineRelativ ==nil then
-		Options.Buttons[ButtonName]:SetPoint("TOPLEFT", Options.NextRelativ,"BOTTOMLEFT", Options.NextRelativX, Options.NextRelativY)
-		Options.NextRelativ=ButtonName
-		Options.LineRelativ=ButtonName
+	local frameIdx=Options.Frames.count+1
+	Options.Frames.count=frameIdx	
+	local buttonName=Options.Prefix .."Button"..frameIdx	
+	local button = CreateFrame("Button", buttonName, Options.CurrentPanel, "UIPanelButtonTemplate")
+	button:ClearAllPoints()
+	button:SetScale(Options.scale)
+	button:SetScript("OnClick", onClick)
+	button:SetHeight(25);
+	(button --[[@as UIPanelButtonTemplate]]):SetTextToFit(text);
+	button.fitTextWidthPadding = 20; -- part of the UIPanelButtonTemplate
+	if not Options.inLine or not Options.LineRelativ then
+		button:SetPoint("TOPLEFT", Options.NextRelativ,"BOTTOMLEFT", Options.NextRelativX, Options.NextRelativY)
+		Options.NextRelativ=buttonName
+		Options.LineRelativ=buttonName
 		Options.NextRelativX=0
 		Options.NextRelativY=0
 	else
-		Options.Buttons[ButtonName]:SetPoint("TOP", Options.LineRelativ,"TOP", 0, 0)
-		Options.Buttons[ButtonName]:SetPoint("LEFT", Options.LineRelativ.."Text","RIGHT", 10, 0)
-		Options.LineRelativ=ButtonName
+		button:SetPoint("TOP", Options.LineRelativ,"TOP", 0, 0)
+		button:SetPoint("LEFT", Options.LineRelativ.."Text","RIGHT", 10, 0)
+		Options.LineRelativ=buttonName
 	end
-	
-	Options.Buttons[ButtonName]:SetScale(Options.scale)
-	Options.Buttons[ButtonName]:SetScript("OnClick", onClick)
-	Options.Buttons[ButtonName]:SetText(text)
-	Options.Buttons[ButtonName]:SetWidth( Options.Buttons[ButtonName]:GetTextWidth()+20 )
-	Options.Buttons[ButtonName]:SetHeight(25)
-	return Options.Buttons[ButtonName]
+	return button
 end
 
 ---@param dbTable table expects either character or account SavedVars table
@@ -672,34 +571,35 @@ end
 ---@param center boolean? if false text topleft justified
 ---@return FontString
 function Options.AddTextToCurrentPanel(text,width,center)
-	local textbox = Options.CurrentPanel:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-	textbox:SetText(text)
-	textbox:SetPoint("TOPLEFT",Options.NextRelativ,"BOTTOMLEFT", Options.NextRelativX, Options.NextRelativY-2)
-	textbox:SetScale(Options.scale)
+	local textFrame = Options.CurrentPanel:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+	textFrame:SetText(text)
+	textFrame:SetPoint("TOPLEFT",Options.NextRelativ,"BOTTOMLEFT", Options.NextRelativX, Options.NextRelativY-2)
+	textFrame:SetScale(Options.scale)
 
 	if width==nil or width==0 then 
-		textbox:SetWidth(textbox:GetStringWidth())
+		textFrame:SetWidth(textFrame:GetStringWidth())
 	elseif width<0 then
-		if string.sub(Options.CurrentPanel:GetName(),  -11)== "ScrollChild" then
-			textbox:SetPoint("RIGHT",Options.CurrentPanel:GetParent():GetParent(),"RIGHT",width,0)
+		if string.sub(Options.CurrentPanel:GetName(),  -11) == "ScrollChild" then
+			-- edge case for scrollable frames
+			textFrame:SetPoint("RIGHT",Options.CurrentPanel:GetParent():GetParent(),"RIGHT",width,0)
 		else
-			textbox:SetPoint("RIGHT",width,0)
+			textFrame:SetPoint("RIGHT",width,0)
 		end
 		if not center then 
-			textbox:SetJustifyH("LEFT")
-			textbox:SetJustifyV("TOP")
+			textFrame:SetJustifyH("LEFT")
+			textFrame:SetJustifyV("TOP")
 		end
 	else
-		textbox:SetWidth(width)
+		textFrame:SetWidth(width)
 		if not center then 
-			textbox:SetJustifyH("LEFT")
-			textbox:SetJustifyV("TOP")
+			textFrame:SetJustifyH("LEFT")
+			textFrame:SetJustifyV("TOP")
 		end
 	end
-	Options.NextRelativ=textbox
+	Options.NextRelativ=textFrame
 	Options.NextRelativX=0
 	Options.NextRelativY=0
-	return textbox
+	return textFrame
 end
 
 ---@param textFrame FontString
@@ -708,9 +608,9 @@ end
 ---@param center boolean?
 function Options.EditText(textFrame,text,width,center)
 	textFrame:SetText(text)
-	if width==nil or width==0 then 
+	if not width or width == 0 then 
 		textFrame:SetWidth(textFrame:GetStringWidth())
-	elseif width<0 then
+	elseif width < 0 then
 		textFrame:SetPoint("RIGHT",width,0)
 		if not center then 
 			textFrame:SetJustifyH("LEFT")

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -150,7 +150,7 @@ local DoRightClick=function(self)
 	DoSelectFilter(false)
 	self:SetChecked(true)
 end
-	
+
 local function SetChatOption()
 	GBB.OptionsBuilder.AddHeaderToCurrentPanel(GBB.L["HeaderChannel"])
 	GBB.OptionsBuilder.Indent(10)	
@@ -278,32 +278,31 @@ local function GenerateExpansionPanel(expansionID)
 end
 
 function GBB.OptionsInit ()
-	GBB.OptionsBuilder.Init(
-		function(panelFrame) -- called when "close" button is pressed	
-			GBB.OptionsBuilder.DoOk() -- saves any widget states to the DB
-			if GBB.DB.TimeOut< 60 then GBB.DB.TimeOut = 60 end
-			GBB.OptionsUpdate()	
-		end,
-		function(panelFrame) -- called whenever the canvas view is refreshed (swapping categories, on open, etc.)
-			local t= GBB.PhraseChannelList(GetChannelList())
-			for i=1,20 do
-				if i<20 then 
-					_G[ChannelIDs[i]:GetName().."Text"]:SetText(i..". "..(t[i] and t[i].name or ""))
-				else
-					_G[ChannelIDs[i]:GetName().."Text"]:SetText((t[i] and t[i].name or ""))
-				end
+	local onCommit = function(panelFrame) -- called when "close" button is pressed	
+		if GBB.DB.TimeOut< 60 then GBB.DB.TimeOut = 60 end
+		GBB.OptionsUpdate()	
+	end
+	-- called whenever the canvas view is refreshed (swapping categories, on open, etc.)
+	local onRefresh = function(panelFrame)
+		local t= GBB.PhraseChannelList(GetChannelList())
+		for i=1,20 do
+			if i<20 then 
+				_G[ChannelIDs[i]:GetName().."Text"]:SetText(i..". "..(t[i] and t[i].name or ""))
+			else
+				_G[ChannelIDs[i]:GetName().."Text"]:SetText((t[i] and t[i].name or ""))
 			end
-			GBB.OptionsBuilder.DoRefresh() -- syncs widgets to DB state
-		end, 
-		function(panelFrame) -- called when the default button is pressed (not implemented for addon panels)
-			GBB.OptionsBuilder.DoDefault() -- reset widgets to default state.
-			GBB.DB.MinimapButton.position=40			
-			GBB.ResetWindow()		
-			GBB.OptionsUpdate()	
 		end
-		)
-	
-	
+	end
+	-- called when the default button is pressed
+	-- note: default button does not exist for addons panels (anymore?), has to be implemented.
+	local onDefault = function(panelFrame)
+		GBB.OptionsBuilder.DefaultRegisteredVariables() -- reset widgets to default state.
+		GBB.DB.MinimapButton.position=40			
+		GBB.ResetWindow()		
+		GBB.OptionsUpdate()	
+	end
+	-- Initialize the options building modulue
+	GBB.OptionsBuilder.Init(onCommit, onRefresh, onDefault);
 	
 	GBB.OptionsBuilder.SetScale(0.85)
 	


### PR DESCRIPTION
**In this PR**:
- clean up public functions for frames not connected with the the `SavedVarRegistry`.
    - includes variable renames, formatting changes, etc.
- Remove post-refactor dead code. 
  - Most of this commented code was related to syncing widgets to saved vars when the `close` button was pressed.