### PR TITLE
hotfix: add translations for "Demon Fall Canyon" dungeon name

### DIFF
--- a/LFGBulletinBoard/dungeons/classic.lua
+++ b/LFGBulletinBoard/dungeons/classic.lua
@@ -149,10 +149,11 @@ local infoOverrides = {
         maxLevel = 60,
         size = 20,
     },
+    -- Demon Fall Canyon
     DFC = isSoD and {
-        name = "Demon Fall Canyon",
-        minLevel = 60, 
-        maxLevel = 60, 
+        name = GetRealZoneText(2784),
+        minLevel = 60,
+        maxLevel = 60,
         typeID = DungeonType.Dungeon,
     },
     -- UBRS is colloquially considered a dungeon. (in LFGDungeon table its a raid)


### PR DESCRIPTION
Uses ID from https://wago.tools/db2/Map?build=1.15.3.55563&filter[MapName_lang]=Demon&page=1 for the translation.

**Images**:
![image](https://github.com/user-attachments/assets/1bbf13f9-f37b-40e6-9d8c-98d0314365f3)

Build checked on:
- [x] SoD
- [x] Era
- [x] Hardcore 