### PR TITLE
revert: re-add "migrate `DropDownMenu` to utilize `SavedVarRegistry`"

### DIFF
--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -325,7 +325,7 @@ function GBB.OptionsInit ()
 	CheckBox("OrderNewTop",true)
 	CheckBox("HeadersStartFolded",false)
 	GBB.OptionsBuilder.AddSpacerToPanel()
-	GBB.OptionsBuilder.AddTextToCurrentPanel(GBB.L["msgFontSize"],-20)
+	GBB.OptionsBuilder.AddTextToCurrentPanel(FONT_SIZE, -20)
 	GBB.OptionsBuilder.AddDropdownToCurrentPanel(GBB.DB,"FontSize", "GameFontNormal", {"GameFontNormalSmall", "GameFontNormal", "GameFontNormalLarge"}) 
 
 	CheckBox("CombineSubDungeons",false)


### PR DESCRIPTION
This is a re-implementation of #275, following @Vysci's reverts in #278 & #279

Id like some more info surrounding the issues you encountered that lead to the reversion, so i know at what point to debug. 
I've gone and checked the state of the addon in commits in #275, #276, #277 on SoD trying to find an error but no luck. 

I havent changed any code from these commits that i'm testing vs the original PR commits (rest of PR's will be submitted after this one), so any errors you encountered would still be in here, thats why i ask.