### PR TITLE
fix: cleanup unnecessary edge case inclusions of `DFC`

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -111,8 +111,7 @@ function GBB.GetDungeonNames()
 		["BREW"] =  "Brewfest - Coren Direbrew",
 		["HOLLOW"] =  "Hallow's End - Headless Horseman",
     	["TRAVEL"] = "Travel services - Summons/Portals",
-		["DFC"] = "Demon Fall Canyon",
-		}
+	}
 
 	local dungeonNamesLocales={
 		deDE ={
@@ -775,11 +774,10 @@ function GBB.GetDungeonSort(additonalCategories)
 	-- Need to do this because I don't know I am too lazy to debug the use of SM2, DM2, and DEADMINES
 	dungeonSort["SM2"] = 10.5
 	dungeonSort["DM2"] = 19.5
-	dungeonSort["DFC"] = 20.5
+
 	-- add reverse link for the SM2 and DM2 for the Combine option 
 	dungeonSort[dungeonSort["SM2"]] = "SM2"
 	dungeonSort[dungeonSort["DM2"]] = "DM2"
-	dungeonSort[dungeonSort["DFC"]] = "DFC"
 
 	-- This is set to a high index with no reverse link because-
 	-- we dont ever want to show this in the list during `UpdateList()` (might not be relevant anymore)

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -691,11 +691,9 @@ function GBB.GetDungeons(msg,name)
 		if nameLevel>0 and nameLevel<40 then
 			dungeons["DM"]=true
 			dungeons["DM2"]=false
-			dungeons["DFC"]=false
 		else
 			dungeons["DM"]=false
 			dungeons["DM2"]=true
-			dungeons["DFC"]=true
 		end
 	end
 

--- a/LFGBulletinBoard/dungeons/classic.lua
+++ b/LFGBulletinBoard/dungeons/classic.lua
@@ -149,7 +149,7 @@ local infoOverrides = {
         maxLevel = 60,
         size = 20,
     },
-    -- Demon Fall Canyon
+    -- Demon Fall Canyon (completely spoofed for SoD since its not added into the LFGDungeon db2 table)
     DFC = isSoD and {
         name = GetRealZoneText(2784),
         minLevel = 60,


### PR DESCRIPTION
**Related Issues**:
 - #281
 - #288
 - #289
 
 
**Changes**:
- `DFC` does not need to be have its dungeonSort index set to a decimal value. 
    - I believe the motivation for fractional dungeonSort values was so that the associated key would not get iterated over in any of the simple integer loops that used the `MAXDUNGEON` related variables.
- `DFC`'s name is defined in `dungeons/classic.lua` and does not need to be set in DefaultEnGB table
- `DFC` does not need to be disambiguated from `DM2` and `DM`.