### PR TITLE
hotfix: add mutual exclusion logic for `HeroicOnly` and `NormalOnly` options

### DIFF
--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -219,8 +219,18 @@ local function GenerateExpansionPanel(expansionID)
 	end
 	
 	if not isClassicEra then
-		CheckBoxChar("HeroicOnly", false)
-		CheckBoxChar("NormalOnly", false)
+		local heroicOnly = CheckBoxChar("HeroicOnly", false)
+		local normalOnly = CheckBoxChar("NormalOnly", false)
+		local exclusiveUpdateHandler = function(updatedBox, mutualBox)
+			return function(newValue) -- both options can be toggled off at the same time, but not on.
+				if newValue == true and mutualBox:GetSavedValue() == true then
+					mutualBox:SetSavedValue(false)
+				end
+				updatedBox:SetChecked(newValue)
+			end
+		end
+		heroicOnly:OnSavedVarUpdate(exclusiveUpdateHandler(heroicOnly, normalOnly))
+		normalOnly:OnSavedVarUpdate(exclusiveUpdateHandler(normalOnly, heroicOnly))
 	end
 	CheckBoxChar("FilterLevel",false)
 	CheckBoxChar("DontFilterOwn",false)


### PR DESCRIPTION
**Related Issues:**
- https://legacy.curseforge.com/wow/addons/lfg-group-finder-bulletin-board?comment=674
- https://legacy.curseforge.com/wow/addons/lfg-group-finder-bulletin-board?comment=677

Adds some logic so that both these options cannot be selected at the same time. Selecting both makes no sense as you're asking for a dungeon that is both heroic and normal.

Previous to this fix, selecting both options would result in empty bulletin boards since no dungeon listing can be classified as both heroic and normal.

![](https://i.imgur.com/W6qLYyU.gif)