### PR TITLE
rework: migrate from deprecated `UIPanelScrollFrameTemplate` to `WowScrollBox` in the settings panels

### DIFF
--- a/LFGBulletinBoard/CustomCategories.lua
+++ b/LFGBulletinBoard/CustomCategories.lua
@@ -727,7 +727,7 @@ local FilterSettingsPool = {
         return legend
     end
 }
----@param scrollPanel Frame Parent panel that the category settings will be drawn onto
+---@param scrollPanel SettingsCategoryPanelScrollChild|Frame Frame that the category settings will be drawn onto
 function Addon.UpdateAdditionalFiltersPanel(scrollPanel)
     ---@cast Addon Addon_Options
 	local userFilters = GroupBulletinBoardDB.CustomFilters
@@ -745,8 +745,6 @@ function Addon.UpdateAdditionalFiltersPanel(scrollPanel)
         local spacer = FilterSettingsPool:AddSpacer(filterSettings)
         if idx == 1 then
             filterSettings:SetPoint("TOPLEFT", nextAnchor, "TOPLEFT", 0, -30)
-            scrollPanel:GetParent().ScrollBar.scrollStep 
-                = filterSettings:GetHeight() + spacer:GetHeight() + (select(5, spacer:GetPoint()) or 0);
         else
             filterSettings:SetPoint("TOPLEFT", nextAnchor, "BOTTOMLEFT", 0, -10)
         end
@@ -760,4 +758,5 @@ function Addon.UpdateAdditionalFiltersPanel(scrollPanel)
         createBtn:SetPoint("TOPLEFT", nextAnchor, "BOTTOMLEFT", 0, -25)
     end
     FilterSettingsPool:PresetsButton(scrollPanel):SetPoint("LEFT", createBtn, "RIGHT", 10, 0)
+    scrollPanel.UpdateScrollLayout(); -- update container scroll layout incase any entries deleted/created
 end

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -407,10 +407,7 @@ function GBB.OptionsInit ()
 	----------------------------------------------------------
 	-- Custom Filters/Categories
 	----------------------------------------------------------
-	local customCategoriesFrame = GBB.OptionsBuilder.AddNewCategoryPanel(ADDITIONAL_FILTERS, false, true);
-	customCategoriesFrame:SetWidth(
-		InterfaceOptionsFramePanelContainer:GetWidth() - customCategoriesFrame:GetParent().ScrollBar:GetWidth()
-	);
+	local customCategoriesFrame = GBB.OptionsBuilder.AddNewCategoryPanel(ADDITIONAL_FILTERS, false, true); 
 	-- defer Update call until after language "Tags" saved vars are initialized bellow
 	----------------------------------------------------------
 	-- Languages and Custom Search Patterns


### PR DESCRIPTION
`UIPanelScrollFrameTemplate` is considered deprecated and was replaced with `WowScrollBox` templates.
We should move away before blizzard deletes the deprecated file (if they ever do).

It pretty much behaves like the old one, theres a scrollChild that you parent your scrollable elements to, instead now the scrollChild will auto size itself based on its content. Similar method will be used when migrating the `RequestList` to `WowScrollBox` in the future.

**Sample Image:**
![example](https://i.imgur.com/6qyjt01.gif)

**Tested On**
- [x] cata
- [x] era 