### PR TITLE
Adding world bosses

### DIFF
--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -1,7 +1,7 @@
 ## Interface: 11503, 40400
 ## Title: LFG Bulletin Board
 ## Notes: Sort LFG/LFM Messages
-## Version: 3.35
+## Version: 3.36
 ## Author: Vyscî-Whitemane
 ## DefaultState: enabled
 ## SavedVariables: GroupBulletinBoardDB

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -144,12 +144,13 @@ local function GenerateExpansionPanel(expansionID)
 	local bgs = GBB.GetSortedDungeonKeys(
 		expansionID, GBB.Enum.DungeonType.Battleground
 	);
-	
+	local enabled = isCurrentXpac
+
 	-- Dungeons 		
 	GBB.OptionsBuilder.AddHeaderToCurrentPanel(DUNGEONS)
 	GBB.OptionsBuilder.Indent(10)
 	for _, key in pairs(dungeons) do
-		tinsert(filters, CheckBoxFilter(key, true))
+		tinsert(filters, CheckBoxFilter(key, enabled))
 	end
 
 	-- different layout for classic era clients
@@ -162,7 +163,7 @@ local function GenerateExpansionPanel(expansionID)
 	GBB.OptionsBuilder.AddHeaderToCurrentPanel(RAIDS)
 	GBB.OptionsBuilder.Indent(10)
 	for _, key in pairs(raids) do
-		tinsert(filters, CheckBoxFilter(key, true))
+		tinsert(filters, CheckBoxFilter(key, enabled))
 	end
 
 	-- Battlegrounds (bg are all consider part of latest expansion atm)

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -149,7 +149,7 @@ local function GenerateExpansionPanel(expansionID)
 	GBB.OptionsBuilder.AddHeaderToCurrentPanel(DUNGEONS)
 	GBB.OptionsBuilder.Indent(10)
 	for _, key in pairs(dungeons) do
-		tinsert(filters, CheckBoxFilter(key, false))
+		tinsert(filters, CheckBoxFilter(key, true))
 	end
 
 	-- different layout for classic era clients
@@ -162,7 +162,7 @@ local function GenerateExpansionPanel(expansionID)
 	GBB.OptionsBuilder.AddHeaderToCurrentPanel(RAIDS)
 	GBB.OptionsBuilder.Indent(10)
 	for _, key in pairs(raids) do
-		tinsert(filters, CheckBoxFilter(key, false))
+		tinsert(filters, CheckBoxFilter(key, true))
 	end
 
 	-- Battlegrounds (bg are all consider part of latest expansion atm)

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -113,6 +113,14 @@ local dungeonTags = {
 		zhTW = "地穴",
 		zhCN = "地穴",
 	},
+	WB = { -- World Bosses
+		enGB = "azu azuregos azregos world bosses wboss kazzak kaz",
+		deDE = nil,
+		ruRU = nil,
+		frFR = nil,
+		zhTW = nil,
+		zhCN = nil,
+	},
 	AZN = { -- Azjol-Nerub
 		enGB = "azn an nerub",
 		deDE = nil,

--- a/LFGBulletinBoard/changelog.txt
+++ b/LFGBulletinBoard/changelog.txt
@@ -1,5 +1,8 @@
 Group Bulletin Board
 
+3.36
+ - Added world bosses for SoD
+
 3.35
  - Fixed a breaking lua error related to the `DFC` dungeon on non Season of Discovery clients.
  - Fixed issue where users were able to filter for both "Normal" and "Heroic" dungeons at the same time.

--- a/LFGBulletinBoard/dungeons/classic.lua
+++ b/LFGBulletinBoard/dungeons/classic.lua
@@ -101,6 +101,7 @@ local LFGDungeonIDs = {
     ["AB"] = 55,  -- Arathi Basin
     ["AV"] = 51,  -- Alterac Valley
     ["DFC"] = isSoD and 830 or nil,  -- Demon Fall Canyon
+    ["WB"] = isSoD and 831 or nil,  -- World Bosses
 }
 -- Note make sure the ID's dont overlap with LFGDungeonIDs
 --see https://wago.tools/db2/GroupFinderActivity?build=1.15.2.54332
@@ -155,6 +156,12 @@ local infoOverrides = {
         minLevel = 60,
         maxLevel = 60,
         typeID = DungeonType.Dungeon,
+    },
+    WB = isSoD and {
+        name = "World Bosses",
+        minLevel = 60,
+        maxLevel = 60,
+        typeID = DungeonType.Raid,
     },
     -- UBRS is colloquially considered a dungeon. (in LFGDungeon table its a raid)
     UBRS = { typeID = DungeonType.Dungeon },


### PR DESCRIPTION
Adding world bosses to SoD. Not adding to era because LFG world bosses is not how it works. 

Decided to add it in 1 category due to the fact people are often searching for "world bosses", so it can apply to multiple categories which is not something that this add-on is capable of handling. It would also end up with a lot of duplicate entries as more bosses are added. Can revisit it in the future

Also enabling the filters to default to being toggled on for current expansion as there has been a lot of ask for this and confusion on why they aren't seeing dungeons