### PR TITLE
[minor][ui]: *disables* the the `lockDistance` option whenever the `UseLibDBIcon` option is enabled

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -473,10 +473,10 @@ local function hooked_createTooltip(self)
 	end
 end
 
-function GBB.Popup_Minimap(frame,notminimap)
+function GBB.Popup_Minimap(frame,showMinimapOptions)
 	local txt="nil"
 	if type(frame)=="table" then txt=frame:GetName() or "nil" end
-	if not GBB.PopupDynamic:Wipe(txt..(notminimap and "notminimap" or "minimap")) then
+	if not GBB.PopupDynamic:Wipe(txt..(showMinimapOptions and "notminimap" or "minimap")) then
 		return
 	end
 
@@ -489,10 +489,15 @@ function GBB.Popup_Minimap(frame,notminimap)
 	GBB.PopupDynamic:AddItem(GBB.L["CboxNotifyChat"],false,GBB.DB,"NotifyChat")
 	GBB.PopupDynamic:AddItem(GBB.L["CboxNotifySound"],false,GBB.DB,"NotifySound")
 	
-	if notminimap~=false then 
+	if showMinimapOptions ~= false then
 		GBB.PopupDynamic:AddItem("",true)
 		GBB.PopupDynamic:AddItem(GBB.L["CboxLockMinimapButton"],false,GBB.DB.MinimapButton,"lock")
-		GBB.PopupDynamic:AddItem(GBB.L["CboxLockMinimapButtonDistance"],false,GBB.DB.MinimapButton,"lockDistance")
+		-- disable whenever the minimap is in LibDBIcon mode
+		if GBB.DB.MinimapButton.UseLibDBIcon then
+			GBB.PopupDynamic:AddItem(GBB.L['CboxLockMinimapButtonDistance'], true, {true}, 1);
+		else
+			GBB.PopupDynamic:AddItem(GBB.L['CboxLockMinimapButtonDistance'], false, GBB.DB.MinimapButton, 'lockDistance')
+		end
 	end
 	GBB.PopupDynamic:AddItem("",true)
 	GBB.PopupDynamic:AddItem(GBB.L["BtnCancel"],false)

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -303,10 +303,20 @@ function GBB.OptionsInit ()
 	GBB.OptionsBuilder.Indent(10)
 	GBB.OptionsBuilder.AddCheckBoxToCurrentPanel(GBB.DB.MinimapButton,"visible",true,GBB.L["Cboxshowminimapbutton"])
 	GBB.OptionsBuilder.AddCheckBoxToCurrentPanel(GBB.DB.MinimapButton,"lock",false,GBB.L["CboxLockMinimapButton"])
-	GBB.OptionsBuilder.AddCheckBoxToCurrentPanel(GBB.DB.MinimapButton,"lockDistance",true,GBB.L["CboxLockMinimapButtonDistance"])
+	local lockDistCheckbox = GBB.OptionsBuilder
+		.AddCheckBoxToCurrentPanel(GBB.DB.MinimapButton,"lockDistance",true,GBB.L["CboxLockMinimapButtonDistance"])
 	if GBB.MinimapButton.isLibDBIconAvailable then
 		local default = GBB.DB.MinimapButton.lockDistance; -- default to the same value as the lockDistance setting
 		GBB.OptionsBuilder.AddCheckBoxToCurrentPanel(GBB.DB.MinimapButton, 'UseLibDBIcon', default, GBB.L.USE_LIBDBICON)
+
+		--- disable the lockDistance checkbox when using `LibDBIcon` since it will be attached to the minimap anyways.
+		local updateHook = function(useLibDBIcon)
+			lockDistCheckbox:SetChecked(useLibDBIcon or  GBB.DB.MinimapButton.lockDistance)
+			lockDistCheckbox:SetEnabled(not useLibDBIcon)
+			lockDistCheckbox.Text:SetTextColor(unpack(useLibDBIcon and {GRAY_FONT_COLOR:GetRGB()} or {WHITE_FONT_COLOR:GetRGB()}))
+		end
+		GBB.OptionsBuilder.GetSavedVarHandle(GBB.DB.MinimapButton, 'UseLibDBIcon'):AddUpdateHook(updateHook);
+		updateHook(GBB.DB.MinimapButton.UseLibDBIcon) -- run once to sync the checkbox state.
 	end
 	GBB.OptionsBuilder.AddSpacerToPanel()
 	CheckBox("ShowTotalTime",false)


### PR DESCRIPTION
Whenever the icon is in `LibDBIcon` mode, its bound to the perimeter of the minimap, which is the same effect of the `lockDistance` option.

In order to prevent confusion, the `lockDistance` option is now disabled (as in grayed and unable to be toggled) whenever the `UseLibDBIcon` option is toggled on.

![WowClassicT_FtMb1pzMoh](https://github.com/user-attachments/assets/6e441daf-7cf1-4fe2-a10e-edc116bfd0fe)
![image](https://github.com/user-attachments/assets/eb240838-3b10-4ee0-b3bf-d69c61f559c1)

