### PR TITLE
[chore]: update changelog and `toc` version for 1.15.4/4.4.1

### DIFF
--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -1,7 +1,7 @@
-## Interface: 11503, 40400
+## Interface: 11504, 40401
 ## Title: LFG Bulletin Board
 ## Notes: Sort LFG/LFM Messages
-## Version: 3.37
+## Version: 3.38
 ## Author: Vyscî-Whitemane
 ## DefaultState: enabled
 ## SavedVariables: GroupBulletinBoardDB

--- a/LFGBulletinBoard/changelog.txt
+++ b/LFGBulletinBoard/changelog.txt
@@ -1,5 +1,10 @@
 Group Bulletin Board
 
+3.38
+ - Fix lua errors from API changes in 1.15.4/4.4.1
+ - added "Firelands" to the Cataclysm raid filter settings.
+ - Added a help message that opens to filter settings when no board results are found __and__ limited filters are selected.
+
 3.37
  - Addon will now prioritize matching chat patterns for Dungeons and Raids from the latest expansion.
    - This fixes an issue where "Bastion of Twilight" was not being tracked because of conflicts with "The Botanica".


### PR DESCRIPTION
Not sure the respective patches are dropping. I will likely do client specific releases of `3.38` if cata/era dont share a patch day.