### PR TITLE
[hotfix]: Add new SoD world boss to `WB` category tags

### DIFF
--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -1,7 +1,7 @@
 ## Interface: 11504, 40401
 ## Title: LFG Bulletin Board
 ## Notes: Sort LFG/LFM Messages
-## Version: 3.38
+## Version: 3.39
 ## Author: Vyscî-Whitemane
 ## DefaultState: enabled
 ## SavedVariables: GroupBulletinBoardDB

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -114,7 +114,7 @@ local dungeonTags = {
 		zhCN = "地穴",
 	},
 	WB = { -- World Bosses
-		enGB = "azu azuregos azregos world bosses wboss kazzak kaz",
+		enGB = "azu azuregos azregos world bosses wboss kazzak kaz thunderan thunderaan",
 		deDE = nil,
 		ruRU = nil,
 		frFR = nil,

--- a/LFGBulletinBoard/changelog.txt
+++ b/LFGBulletinBoard/changelog.txt
@@ -1,5 +1,8 @@
 Group Bulletin Board
 
+3.39
+  - Adds `thunderaan` and `thunderan` as english keywords to the SoD "World Bosses" category.
+
 3.38
  - Fix lua errors from API changes in 1.15.4/4.4.1
  - added "Firelands" to the Cataclysm raid filter settings.


### PR DESCRIPTION
- adds `thunderan` and `thunderaan` keywords for the new Crystal Veil "raid" (its an instanced boss like other world bosses), added in SoD phase 5 .
- opted to just adding additional tags to the "World Bosses" category as opposed to its own "The Crystal Veil" dungeon category.