### PR TITLE
[chore]: update changelog's existing `v3.39` release notes for Cata release

### DIFF
--- a/LFGBulletinBoard/changelog.txt
+++ b/LFGBulletinBoard/changelog.txt
@@ -1,11 +1,12 @@
 Group Bulletin Board
 
 3.39
-  - Adds `thunderaan` and `thunderan` as english keywords to the SoD "World Bosses" category.
+  - Fix lua errors from API changes in 4.4.1
+  - Added "Firelands" to the Cataclysm raid filter settings (done in 3.38).
+  - Added crystal vale for SoD clients
 
 3.38
- - Fix lua errors from API changes in 1.15.4/4.4.1
- - added "Firelands" to the Cataclysm raid filter settings.
+ - Fix lua errors from API changes in 1.15.4
  - Added a help message that opens to filter settings when no board results are found __and__ limited filters are selected.
 
 3.37


### PR DESCRIPTION
Caused by blizz having staggered client releases 1.15.4/4.4.1 and our monorepo style setup.