### PR TITLE
[hotfix][rework]: Add text replacements for the `alt-click` whisper feature

### DIFF
--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -83,7 +83,7 @@ local function InviteRequestWithRole(gbbName,gbbDungeon,gbbHeroic,gbbRaid)
 		gbbDungeonPrefix = ""
 	end
 
-	SendChatMessage(string.format(GBB.L["msgLeaderOutbound"], gbbDungeonPrefix .. GBB.dungeonNames[gbbDungeon], GBB.DB.InviteRole), "WHISPER", nil, gbbName)
+	SendChatMessage(string.format(GBB.L["JOIN_REQUEST_MESSAGE"], gbbDungeonPrefix .. GBB.dungeonNames[gbbDungeon], GBB.DB.InviteRole), "WHISPER", nil, gbbName)
 end
 
 local function IgnoreRequest(name)

--- a/LFGBulletinBoard/Localization.lua
+++ b/LFGBulletinBoard/Localization.lua
@@ -100,8 +100,7 @@ GBB.locales = {
 		["normalAbr"]="N",
 		["raidAbr"]="R",
 		["msgFontSize"] = "Font Size (Requires /reload)",
-		["msgLeaderOutbound"]="Please invite for %s, I am a %s.",
-
+		["JOIN_REQUEST_MESSAGE"]="Please invite for %dungeon. Level %level %class %role.",
 		-- option panel
 
 		["HeaderSettings"]="Settings",
@@ -352,7 +351,7 @@ GBB.locales = {
 	["normalAbr"]="N",
 	["raidAbr"]="R",
 	["msgFontSize"] = "Taille de fonte (nécéssite un /reload)",
-	["msgLeaderOutbound"]="Je cherche un groupe pour %s, Je suis %s.",
+	["JOIN_REQUEST_MESSAGE"]="Je cherche un groupe pour %dungeon, Je suis %role.",
 	["HeaderSettings"]="Réglages",
 	["PanelFilter"]="Filtres Vanilla",
 	["TBCPanelFilter"]="Filtres BC",

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -478,18 +478,20 @@ function GBB.OptionsInit ()
 	saveText:SetAlpha(0.75)
 	GBB.OptionsBuilder.AddSpacerToPanel()
 	local locales= GBB.locales.enGB
-	local t={}
-	for key, _ in pairs(locales) do 
-		table.insert(t,key)
+	local displayStrKeys = {}
+	for key, _ in pairs(locales) do
+		table.insert(displayStrKeys, key)
 	end
-	table.sort(t)
-	for _,key in ipairs(t) do 
-		
-		local col=GBB.L[key]~=nil and "|cffffffff" or "|cffff4040"
-		local txt=GBB.L[key.."_org"]~="["..key.."_org]" and GBB.L[key.."_org"] or GBB.L[key]
-				
-		GBB.OptionsBuilder.AddEditBoxToCurrentPanel(GBB.DB.CustomLocales,key,"",col.."["..key.."]",450,200,false,locales[key],txt)
-		
+	table.sort(displayStrKeys)
+	for _,key in ipairs(displayStrKeys) do
+		-- _org suffix is used for saving the original value if changed by user.
+		if not key:find("_org") then
+			local labelTxt = WrapTextInColorCode(('[%s]'):format(key), GBB.L[key]~=nil and "ffffffff" or "ffff4040")
+			local sampleTxt = (GBB.L[key] and GBB.L[key]~="") and GBB.L[key] or GBB.L[key.."_org"]
+			GBB.OptionsBuilder.AddEditBoxToCurrentPanel(GBB.DB.CustomLocales, key,
+				"", labelTxt, 450, 200, false,locales[key], sampleTxt
+			)
+		end
 	end
 	--locales dungeons
 	GBB.OptionsBuilder.AddSpacerToPanel()


### PR DESCRIPTION
relates issues:
 - #324 
 
Current replacements added are:
 - `%level` - player level
 - `%class` - player class
 - `%role` - role selected in addon filters panel
 - `%dungeon` - name of dungeon/activity