### PR TITLE
[hotfix]: use proper fallback for empty `CustomLocales.JOIN_REQUEST_MESSAGE` strings

### DIFF
--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -409,7 +409,10 @@ end
 ---@param isHeroic boolean?
 local function SendJoinRequestMessage(leaderName, dungeonKey, isHeroic)
 	local dungeon = GBB.dungeonNames[dungeonKey] or dungeonKey
-	local msg = GBB.DB.CustomLocales.JOIN_REQUEST_MESSAGE or GBB.L.JOIN_REQUEST_MESSAGE ---@type string
+	local msg = GBB.DB.CustomLocales.JOIN_REQUEST_MESSAGE
+	if not msg or strlen(msg) == 0 then -- fallback to default message
+		msg = GBB.L.JOIN_REQUEST_MESSAGE
+	end
 	local replacements = {
 		-- note: the '%' in '%key' needs to be lua escaped with another '%' for the `gsub` function.
 		-- (they DO NOT need to be escaped in the JOIN_REQUEST_MESSAGE string).


### PR DESCRIPTION
The `Localization.lua` files logic auto inserts an empty string value (`""`) for the `CustomLocales` table. Might be worth to keep these entries `nil` instead in the future.