### PR TITLE
[refactor]: seperate out World Bosses from Raids for classic

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -667,7 +667,7 @@ local pvpNames = GBB.GetSortedDungeonKeys(nil, GBB.Enum.DungeonType.Battleground
 
 local debugNames = {"DEBUG", "BAD", "NIL"}
 
-local raidNames = GBB.GetSortedDungeonKeys(nil, GBB.Enum.DungeonType.Raid);
+local raidNames = GBB.GetSortedDungeonKeys(nil,{ GBB.Enum.DungeonType.Raid, GBB.Enum.DungeonType.WorldBoss });
 
 -- Becasue theyre not actually dungeons and are not parsed by 
 -- `/data/dungeons/{version}.lua` we need to add them manually
@@ -708,9 +708,9 @@ end
 
 -- used in Tags.lua for determining which tags are safe for game version
 -- used in Options.lua for determining adding filter boxes
-GBB.VanillaDungeonKeys = GBB.GetSortedDungeonKeys(
+local vanillaDungeonKeys = GBB.GetSortedDungeonKeys(
 	GBB.Enum.Expansions.Classic,
-	{ GBB.Enum.DungeonType.Dungeon, GBB.Enum.DungeonType.Raid }
+	{ GBB.Enum.DungeonType.Dungeon, GBB.Enum.DungeonType.Raid, GBB.Enum.DungeonType.WorldBoss }
 );
 
 -- clear unused dungeons in classic to not generate options/checkboxes with the-
@@ -739,11 +739,11 @@ function GBB.GetDungeonSort(additonalCategories)
 		additonalCategories = {} --[[@as string[] ]]
 	end
 	local dungeonOrder = { 
-		GBB.VanillaDungeonKeys, tbcDungeonNames, wotlkDungeonNames, cataDungeonKeys, 
+		vanillaDungeonKeys, tbcDungeonNames, wotlkDungeonNames, cataDungeonKeys, 
 		pvpNames, additonalCategories, GBB.Misc, debugNames
 	}
 
-	local vanillaDungeonSize = #GBB.VanillaDungeonKeys
+	local vanillaDungeonSize = #vanillaDungeonKeys
 	local tbcDungeonSize = #tbcDungeonNames
 	local wotlkDungeonSize = #wotlkDungeonNames
 	local cataDungeonSize = #cataDungeonKeys

--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -1,5 +1,5 @@
 local TOCNAME,
-	---@class Addon_Dungeons : Addon_DungeonData	
+	---@class Addon_Dungeons : Addon_Tags, Addon_DungeonData
 	GBB = ...;
 
 local isClassicEra = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
@@ -712,10 +712,6 @@ GBB.VanillaDungeonKeys = GBB.GetSortedDungeonKeys(
 	GBB.Enum.Expansions.Classic,
 	{ GBB.Enum.DungeonType.Dungeon, GBB.Enum.DungeonType.Raid }
 );
-
-
--- table used in Tags.lua for determining which tags are safe for game version
-GBB.Misc = {"MISC", "TRADE", "TRAVEL"}
 
 -- clear unused dungeons in classic to not generate options/checkboxes with the-
 -- new data pipeline api these tables should already empty anyways when in classic client

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -448,7 +448,7 @@ function GBB.CreateTagList ()
 		GBB.heroicTagsLoc["custom"]=GBB.Split(GBB.DB.Custom.Heroic)
 
 		local sortedDungeonKeys = GBB.GetSortedDungeonKeys( -- dungeons & raids for all expansions
-			nil, {GBB.Enum.DungeonType.Dungeon, GBB.Enum.DungeonType.Raid}
+			nil, {GBB.Enum.DungeonType.Dungeon, GBB.Enum.DungeonType.Raid, GBB.Enum.DungeonType.WorldBoss}
 		)
 		-- insert a "custom" locale to `dungeonTagsLoc` for custom tags (before calling `setTagListByLocale`).
 		GBB.dungeonTagsLoc["custom"]={}

--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -14,8 +14,8 @@ Localization.lua
 dungeons/classic.lua
 dungeons/cata.lua
 CustomCategories.lua
-Dungeons.lua
 Tags.lua
+Dungeons.lua
 RequestList.lua
 Options.lua
 GroupList.Lua

--- a/LFGBulletinBoard/Localization.lua
+++ b/LFGBulletinBoard/Localization.lua
@@ -94,6 +94,16 @@ local localizedAddonDisplayStrings = {
         ruRU = "Доступные замены:|n%role - Роль |n%class - Класс |n%level - Уровень |n%dungeon - Подземелье",
         zhCN = "可用替换：|n%role - 职责 |n%class - 职业 |n%level - 等级 |n%dungeon - 地下城",
         zhTW = "適用的替代項目：|n%role - 角色類型 |n%class - 職業 |n%level - 等級 |n%dungeon - 地城",
+	},
+	WORLD_BOSSES = {
+		enUS = "World Bosses",
+        deDE = "Weltbosse",
+        esMX = "Jefes de mundo",
+        frFR = "Boss hors instance",
+        ptBR = "Chefes Mundiais",
+        ruRU = "Боссы вне подземелий",
+        zhCN = "世界首领们",
+        zhTW = "世界首領們",
 	}
 }
 ---Localized addon strings, keyed by locale

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -169,7 +169,17 @@ local function GenerateExpansionPanel(expansionID)
 	for _, key in pairs(raids) do
 		tinsert(filters, CheckBoxFilter(key, enabled))
 	end
-
+	if isClassicEra then -- World Bosses
+		local bosses = GBB.GetSortedDungeonKeys(expansionID, GBB.Enum.DungeonType.WorldBoss)
+		if #bosses > 0 then
+			GBB.OptionsBuilder.Indent(-10)
+			GBB.OptionsBuilder.AddHeaderToCurrentPanel(GBB.L.WORLD_BOSSES)
+			GBB.OptionsBuilder.Indent(10)
+			for _, key in pairs(bosses) do
+				tinsert(filters, CheckBoxFilter(key, enabled))
+			end
+		end
+	end
 	-- Battlegrounds (bg are all consider part of latest expansion atm)
 	if #bgs > 0 then
 		if isCurrentXpac and not isClassicEra then

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -113,20 +113,17 @@ local dungeonTags = {
 		zhTW = "地穴",
 		zhCN = "地穴",
 	},
-	WB = { -- World Bosses
-		enGB = "azu azuregos azregos world bosses wboss kazzak kaz",
-		deDE = nil,
-		ruRU = nil,
-		frFR = nil,
-		zhTW = nil,
-		zhCN = nil,
+	AZGS = { -- Azuregos
+		enGB = "azu azuregos azregos",
 	},
-	CRY = { -- Crystal vale
+	KAZK = { -- Lord Kazzak
+		enGB = "kazzak kaz",
+	},
+	CRY = { -- Crystal vale (Thunderaan)(SoD only)
 		enGB = "crystal vale thunderan thunderaan",
-		ruRU = nil,  
-		frFR = nil,  
-		zhTW = nil,
-		zhCN = nil,
+	},
+	NMG = { -- Nightmare Grove (Emerald Dragons)(SoD only)
+		enGB = "grove nmg dragons",
 	},
 	AZN = { -- Azjol-Nerub
 		enGB = "azn an nerub",

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -1,5 +1,5 @@
 local TOCNAME, 
-	---@class Addon_Tags: Addon_Dungeons
+	---@class Addon_Tags: Addon_DungeonData
 	GBB = ...;
 
 local isClassicEra = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
@@ -1055,9 +1055,11 @@ local miscTags = {
 	  zhTW = nil,
 	  zhCN = nil,
 	},
+	MISC = { --[[Misc messages, no defined tags. see `GBB.GetDungeons`]]},
 }
 
---- Secondary Dungeon Tags: related to identifying dungeon or activity name from a message.
+--- Secondary Dungeon Tags: used for groupable categories such as Scarlet Monastery
+--- note: DEADMINES entry used for an edge case in categorizing between Dire Maul and Deadmines
 local dungeonSecondTags = {
 	["DEADMINES"] = { "DM", "-DMW", "-DME", "-DMN" },
 	["SM2"] = { "SMG", "SML", "SMA", "SMC" },
@@ -1082,31 +1084,24 @@ for _, categoryTags in pairs({dungeonTags, miscTags}) do
 	end
 end
 
-GBB.dungeonTagsLoc = dungeonTagsLoc
 GBB.dungeonSecondTags = dungeonSecondTags
 GBB.suffixTagsLoc = langSplit(suffixTags)
 GBB.searchTagsLoc = langSplit(searchTags)
 GBB.badTagsLoc = langSplit(badTags)
 GBB.heroicTagsLoc = langSplit(heroicTags)
+GBB.Misc = (function() local t = {}; for k, _ in pairs(miscTags) do table.insert(t,k); end return t; end)()
 
+GBB.dungeonTagsLoc = dungeonTagsLoc
 -- Remove any unused dungeon tags based on game version
-
--- Passing no specific dungeonType or ExpansionID will yeild all available.
--- This includes raids/bgs/arenas/dungeons from classic up to current expansion
-local validDungeonKeys = GBB.GetSortedDungeonKeys()
-local validGameVersionKeys = {}
-for _, key in ipairs(validDungeonKeys) do
-	validGameVersionKeys[key] = true
-end
--- manually add MISC entries to validGameVersionKeys, this is kinda hacky atm.
-for _, key in ipairs(GBB.Misc) do	
-	validGameVersionKeys[key] = true
-end
+local clientDungeonKeys = GBB.GetSortedDungeonKeys() -- includes raids/bgs/dungeons for all valid expansions.
+clientDungeonKeys = (function() ---@type table<string, boolean> convert to map
+	local t = {}; for _, key in ipairs(clientDungeonKeys) do t[key] = true; end return t;
+end)()
 -- iterate over all locales and `nil` out any entries for dungeons not in current client
 for locale, dungeonTags in pairs(GBB.dungeonTagsLoc) do
 	for dungeonKey, _ in pairs(dungeonTags) do
-		if not (validGameVersionKeys[dungeonKey] 
-			or GBB.dungeonSecondTags[dungeonKey]
+		if not (clientDungeonKeys[dungeonKey]
+			or dungeonSecondTags[dungeonKey]
 			or miscTags[dungeonKey])
 		then
 			GBB.dungeonTagsLoc[locale][dungeonKey] = nil

--- a/LFGBulletinBoard/dungeons/classic.lua
+++ b/LFGBulletinBoard/dungeons/classic.lua
@@ -88,12 +88,11 @@ local LFGActivityIDs = {
     ["AB"] = 930,  -- Arathi Basin [926-930]
     ["AV"] = 932,  -- Alterac Valley
     -- SoD Specific
-    ["WB"] = isSoD and 6969 or nil,  -- World Bosses (Used to group Azuregoes/Kazzak) *spoofed*
     ["DFC"] = isSoD and 1607 or nil, -- Demon Fall Canyon
-    -- ["AZGS"] = isSoD and 1608 or nil, -- Storm Cliffs (Azuregoes)
-    -- ["KAZK"] = isSoD and 1609 or nil, -- Tainted Scar (Kazzak)
+    ["AZGS"] = isSoD and 1608 or nil, -- Storm Cliffs (Azuregoes)
+    ["KAZK"] = isSoD and 1609 or nil, -- Tainted Scar (Kazzak)
     ["CRY"] = isSoD and 1611 or nil, -- Crystal Vale (Thunderaan)
-    -- ["NMG"] = isSoD and 1610 or nil, -- Nightmare Grove (Emerald Dragons)
+    ["NMG"] = isSoD and 1610 or nil, -- Nightmare Grove (Emerald Dragons)
 }
 --see https://wago.tools/db2/GroupFinderCategory?build=1.15.2.54332
 local activityCategoryTypeID  = {
@@ -116,12 +115,6 @@ local infoOverrides = {
     WSG = { minLevel = 10, maxLevel = 60 },
     AB = { minLevel = 20, maxLevel = 60 },
     -- Note: Following entries for are completely spoofed. hardcoded info here.
-    WB = isSoD and {
-        name = "World Bosses",
-        minLevel = 60,
-        maxLevel = 60,
-        typeID = DungeonType.Raid,
-    },
     SM2 = {
         name = GetRealZoneText(189),
         minLevel = 30, -- SMG min

--- a/LFGBulletinBoard/dungeons/classic.lua
+++ b/LFGBulletinBoard/dungeons/classic.lua
@@ -29,6 +29,7 @@ local DungeonType = {
     Raid = 2,
     None = 4,
     Battleground = 5, -- in classic, 5 is used for BGs
+    WorldBoss = 6,
 }
 
 ---@enum ExpansionID
@@ -108,7 +109,11 @@ local infoOverrides = {
     -- ex: https://wago.tools/db2/DungeonEncounter?build=1.15.5.57638&sort[Name_lang]=asc&filter[ID]=3079
     CRY = isSoD and {
         name = "Crystal Vale - Prince Thunderaan",
+        typeID = DungeonType.WorldBoss,
     },
+    AZGS = { typeID = DungeonType.WorldBoss },
+    KAZK = { typeID = DungeonType.WorldBoss },
+    NMG = isSoD and { typeID = DungeonType.WorldBoss },
     -- Strat is split into "Main"/"Service" Gates between 2 IDs. We use just the plain zone name.
     STR = { name = GetRealZoneText(329) },
     -- GetActivityInfoTable has unique entries for each BG level bracket. We however use a single entry.


### PR DESCRIPTION
**In this PR**:
- The World Bosses category `WB`  which was used as catch-all for the first 2 world bosses released on SoD, has been removed.
  - in its place `AZGS` and `KAZK` have been added to the propper data tables. 
- Adds the new world boss category comming for sod phase 6
    - `NMG` - for "Nightmare grove", (emerald dragons)
    -  These may need to be seperated out in the future for regular non-sod era.
- Added a new entry to the Addons `Enum.DungeonType` table for `WorldBosses`.
  - Note: The `GetActivityInfoTable` API identifies the SoD World Bosses as `DungeonType.Raid` so these have to be overridden to our spoofed Enum for the World Bosses.
- Includes a "World Bosses" header in the settings panel for classic filters
- ![WowClassic_PNVr9TLBS3](https://github.com/user-attachments/assets/cd530286-f580-4f6e-bf6a-43ebad1ceb77)

