### PR TITLE
[minor]: change the display name for world bosses

### DIFF
--- a/LFGBulletinBoard/Localization.lua
+++ b/LFGBulletinBoard/Localization.lua
@@ -104,7 +104,37 @@ local localizedAddonDisplayStrings = {
         ruRU = "Боссы вне подземелий",
         zhCN = "世界首领们",
         zhTW = "世界首領們",
-	}
+	},
+	LORD_KAZZAK = {
+		enUS = "Lord Kazzak",
+		deDE = "Lord Kazzak",
+		esMX = "Lord Kazzak",
+		frFR = "Seigneur Kazzak",
+		ptBR = "Lorde Kazzak",
+		ruRU = "Владыка Каззак",
+		zhCN = "卡扎克",
+		zhTW = "卡札克領主",
+	},
+	AZUREGOS = {
+		enUS = "Azuregos",
+		deDE = "Azuregos",
+		esMX = "Azuregos",
+		frFR = "Azuregos",
+		ptBR = "Azuregos",
+		ruRU = "Азурегос",
+		zhCN = "艾索雷葛斯",
+		zhTW = "艾索雷苟斯",
+	},
+	THUNDERAAN = {
+		enUS = "Prince Thunderaan",
+		deDE = "Prinz Donneraan",
+		esMX = "Príncipe Thunderaan",
+		frFR = "Prince Tonneraan",
+		ptBR = "Príncipe Trovejardus",
+		ruRU = "Принц Громораан",
+		zhCN = "桑德兰王子",
+		zhTW = "桑德蘭王子",
+	},
 }
 ---Localized addon strings, keyed by locale
 GBB.locales = {

--- a/LFGBulletinBoard/dungeons/classic.lua
+++ b/LFGBulletinBoard/dungeons/classic.lua
@@ -1,5 +1,5 @@
 local tocName,
-    ---@class Addon_DungeonData
+    ---@class Addon_DungeonData: Addon_Localization
     addon = ...;
 
 if WOW_PROJECT_ID ~= WOW_PROJECT_CLASSIC then return end
@@ -41,6 +41,11 @@ local Expansions = {
 }
 
 local isSoD = C_Seasons and (C_Seasons.GetActiveSeason() == Enum.SeasonID.SeasonOfDiscovery)
+
+-- hacky way to get the localization table. rework in the future
+-- side-effects:
+-- custom users set translatiosn in the `Localization` settings panel will not apply to strings used in this file.
+local L = addon.LocalizationInit()
 
 local debug = false
 local print = function(...) if debug then print(tocName, ...) end end
@@ -105,14 +110,9 @@ local idToDungeonKey = tInvert(LFGActivityIDs)
 
 --- Any info that needs to be overridden/spoofed for a specific instances should be done here.
 local infoOverrides = {
-    -- todo: add the localized boss name, to the parsed dungeon name for the SoD instanced world bosses.
-    -- ex: https://wago.tools/db2/DungeonEncounter?build=1.15.5.57638&sort[Name_lang]=asc&filter[ID]=3079
-    CRY = isSoD and {
-        name = "Crystal Vale - Prince Thunderaan",
-        typeID = DungeonType.WorldBoss,
-    },
-    AZGS = { typeID = DungeonType.WorldBoss },
-    KAZK = { typeID = DungeonType.WorldBoss },
+    CRY = isSoD and { name = L.THUNDERAAN, typeID = DungeonType.WorldBoss },
+    AZGS = { name = L.AZUREGOS, typeID = DungeonType.WorldBoss },
+    KAZK = { name = L.LORD_KAZZAK, typeID = DungeonType.WorldBoss },
     NMG = isSoD and { typeID = DungeonType.WorldBoss },
     -- Strat is split into "Main"/"Service" Gates between 2 IDs. We use just the plain zone name.
     STR = { name = GetRealZoneText(329) },


### PR DESCRIPTION
The game uses the zone name for these, but community normally identifies them by the boss name.

May need to add the emerald dragons bosses in the future, however for SoD they will all be in the same instance so i kept that one as the zone name "Nightmare Grove"