### PR TITLE
[minor]: Remove guild rank from the `EnableGuild` tooltip

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -485,9 +485,9 @@ local function hooked_createTooltip(self)
 	if (name) and (unit) and UnitIsPlayer(unit) then
 	
 		if GBB.DB.EnableGuild then
-			local guildName, guildRankName, guildRankIndex, realm = GetGuildInfo(unit)
-			if guildName and guildRankName then
-				self:AddLine(GBB.Tool.RGBtoEscape(GBB.DB.ColorGuild).."< "..guildName.." / "..guildRankName.." >")
+			local guildName = GetGuildInfo(unit)
+			if guildName then
+				self:AddLine(Mixin(ColorMixin, GBB.DB.ColorGuild):WrapTextInColorCode(("<%s>"):format(guildName)))
 			end
 		end
 


### PR DESCRIPTION
If ever requested can add the option to include the rank back in.

**note:** the `EnableGuild` option should either removed altogether, or at least only limited to addon created tooltips in the future.

fixes #329 