### PR TITLE
[Feature][Era]: Support Group Finder tool on Anniversary/SoD realms. 

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -360,10 +360,6 @@ function GBB.BtnSettings(button )
 		--GBB.Options.Open(1)
 	end
 end
-
-function GBB.BtnRefresh(button)
-	GBB.UpdateLfgTool()
-end
 --------------------------------------------------------------------------------
 -- Tag Lists
 --------------------------------------------------------------------------------
@@ -600,12 +596,9 @@ function GBB.Init()
 
 	-- Reset Request-List
 	GBB.RequestList={}
-	GBB.LfgRequestList={}
 	GBB.FramesEntries={}
-	GBB.LfgFramesEntries = {}
 
 	GBB.FoldedDungeons={}
-	GBB.LfgFoldedDungeons = {}
 	
 	-- Timer-Stuff
 	GBB.MAXTIME=time() +60*60*24*365 --add a year!
@@ -956,21 +949,12 @@ function GBB.OnUpdate(elapsed)
 			if GBB.Tool.GetSelectedTab(GroupBulletinBoardFrame)==1 then
 				GBB.UpdateList()
 			elseif  GBB.Tool.GetSelectedTab(GroupBulletinBoardFrame)==2 then
-				GBB.UpdateLfgToolNoSearch()
+				GBB.UpdateLfgTool()
 			end
-				
 			GBB.ElapsedSinceListUpdate = 0;
 		else
 			GBB.ElapsedSinceListUpdate = GBB.ElapsedSinceListUpdate + elapsed;
 		end;
-
-		if GBB.ElapsedSinceLfgUpdate > 18 and GBB.Tool.GetSelectedTab(GroupBulletinBoardFrame)==2 and GroupBulletinBoardFrame:IsVisible() then
-			-- LFGListFrame.SearchPanel.RefreshButton:Click() -- hwevent protected
-			GBB.UpdateLfgTool()
-			GBB.ElapsedSinceLfgUpdate = 0
-		else
-			GBB.ElapsedSinceLfgUpdate = GBB.ElapsedSinceLfgUpdate + elapsed
-		end
 	end
 end
 

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -327,7 +327,6 @@ function GBB.ShowWindow()
 
     -- Check if classic or not
     if string.sub(version, 1, 2) ~= "1." then
-		GBB.UpdateLfgTool()
 		GBB.UpdateGroupList()
     end
 	GroupBulletinBoardFrame:Show()
@@ -949,8 +948,6 @@ function GBB.OnUpdate(elapsed)
 		if GBB.ElapsedSinceListUpdate > 1 then
 			if GBB.Tool.GetSelectedTab(GroupBulletinBoardFrame)==1 then
 				GBB.UpdateList()
-			elseif  GBB.Tool.GetSelectedTab(GroupBulletinBoardFrame)==2 then
-				GBB.UpdateLfgTool()
 			end
 			GBB.ElapsedSinceListUpdate = 0;
 		else

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -710,6 +710,7 @@ function GBB.Init()
 	
 	---@type EditBox # making this local isnt required, just here for the luals linter
 	local GroupBulletinBoardFrameResultsFilter = _G["GroupBulletinBoardFrameResultsFilter"];
+	GroupBulletinBoardFrameResultsFilter:SetParent(GroupBulletinBoardFrame_ScrollFrame)
 	GroupBulletinBoardFrameResultsFilter.filterPatterns = { };
 	GroupBulletinBoardFrameResultsFilter:SetFontObject(GBB.DB.FontSize);
 	GroupBulletinBoardFrameResultsFilter:SetTextColor(1, 1, 1, 1);
@@ -760,35 +761,41 @@ function GBB.Init()
 	GBB.PopupDynamic=GBB.Tool.CreatePopup(GBB.OptionsUpdate)
 	GBB.InitGroupList()
 
-	if isClassicEra then
+	if isClassicEra then -- setup tabs
+		-- Normal requests tab
 		GBB.Tool.AddTab(GroupBulletinBoardFrame, GBB.L.TabRequest, GroupBulletinBoardFrame_ScrollFrame);
-		
+
+		-- LFG Tool tab. Note: currently only active in anniversary(fresh) servers and SoD
+		local serverType = C_Seasons.GetActiveSeason()
+		if (serverType == Enum.SeasonID.SeasonOfDiscovery)
+		or (serverType == Enum.SeasonID.Fresh)
+		or (serverType == Enum.SeasonID.FreshHardcore)
+		then GBB.Tool.AddTab(GroupBulletinBoardFrame, GBB.L.TabLfg, GroupBulletinBoardFrame_LfgFrame);
+		else GroupBulletinBoardFrame_LfgFrame:Hide() end;
+
+		-- Past group members tab. (Inactive and broken)
 		-- GBB.Tool.AddTab(GroupBulletinBoardFrame, GBB.L.TabGroup, GroupBulletinBoardFrame_GroupFrame);
 		GroupBulletinBoardFrame_GroupFrame:Hide()
-		
-		-- Group Finder doesnt exist in classic era
-		GroupBulletinBoardFrame_LfgFrame:Hide()
-	else -- cata client
-		-- Hide all tabs except requests for the time being
-		
+	else
+		-- cata client for Hide all tabs except requests for the time being
 		GBB.Tool.AddTab(GroupBulletinBoardFrame, GBB.L.TabRequest, GroupBulletinBoardFrame_ScrollFrame);
+
+		-- GBB.Tool.AddTab(GroupBulletinBoardFrame, GBB.L.TabLfg, GroupBulletinBoardFrame_LfgFrame);
+		GroupBulletinBoardFrame_LfgFrame:Hide()
 
 		-- GBB.Tool.AddTab(GroupBulletinBoardFrame, GBB.L.TabGroup, GroupBulletinBoardFrame_GroupFrame);
 		GroupBulletinBoardFrame_GroupFrame:Hide()
-		
-		-- GBB.Tool.AddTab(GroupBulletinBoardFrame, GBB.L.TabLfg, GroupBulletinBoardFrame_LfgFrame);
-		GroupBulletinBoardFrame_LfgFrame:Hide()
+
 	end
-	GBB.Tool.SelectTab(GroupBulletinBoardFrame,1)
+	GBB.Tool.SelectTab(GroupBulletinBoardFrame, 1) -- default to requests tab
 	local enableGroupVar = GBB.OptionsBuilder.GetSavedVarHandle(GBB.DB, "EnableGroup")
 	local refreshGroupTab = function(isEnabled) -- previously done in `GBB.OptionsUpdate()`
 		if isEnabled then
 			-- Shows all active tabs.
 			GBB.Tool.TabShow(GroupBulletinBoardFrame)
-		else -- note: only the request-list tab is currently active on cata & era.
-			GBB.Tool.SelectTab(GroupBulletinBoardFrame, 1)
+		else
 			-- hide the "Remember past group members" aka "EnableGroup" tab should be the last tab
-			GBB.Tool.TabHide(GroupBulletinBoardFrame, isClassicEra and 2 or 3)
+			GBB.Tool.TabHide(GroupBulletinBoardFrame, isClassicEra and 3 or 2)
 		end
 	end
 	enableGroupVar:AddUpdateHook(refreshGroupTab)

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -320,11 +320,6 @@ function GBB.ResizeFrameList()
 	w=GroupBulletinBoardFrame:GetWidth() -20-10-10
 	GroupBulletinBoardFrame_ScrollFrame:SetWidth( w )
 	GroupBulletinBoardFrame_ScrollChildFrame:SetWidth( w )
-
-	GroupBulletinBoardFrame_LfgFrame:SetHeight(GroupBulletinBoardFrame:GetHeight() -55-25 )
-	w=GroupBulletinBoardFrame:GetWidth() -20-10-10
-	GroupBulletinBoardFrame_LfgFrame:SetWidth( w )
-	GroupBulletinBoardFrame_LfgChildFrame:SetWidth( w )
 end
 
 function GBB.ShowWindow()
@@ -545,6 +540,8 @@ function GBB.Popup_Minimap(frame,showMinimapOptions)
 end
 
 function GBB.Init()
+	GroupBulletinBoardFrame_LfgFrame:Hide() -- todo: remove deprecated frame from xml
+	local GroupBulletinBoardFrame_LfgFrame = GBB.LfgTool.ScrollContainer -- use new frame
 	GroupBulletinBoardFrame:SetResizeBounds(400,170)	
 	GroupBulletinBoardFrame:SetClampedToScreen(true)
 	GBB.UserLevel=UnitLevel("player")
@@ -599,6 +596,9 @@ function GBB.Init()
 	-- Add tags for custom categories into `dungeonTagsLoc`. 
 	-- Must do before the call to `GBB.CreateTagList()` below
 	GBB.SyncCustomFilterTags(GBB.dungeonTagsLoc);
+
+	-- Load LFGList tool module
+	GBB.LfgTool:Load()
 
 	-- Reset Request-List
 	GBB.RequestList={}

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -791,10 +791,11 @@ function GBB.Init()
 	end
 	enableGroupVar:AddUpdateHook(refreshGroupTab)
 	refreshGroupTab(enableGroupVar:GetValue()) -- run once to match the set state.
-	
 	GBB.Tool.TabOnSelect(GroupBulletinBoardFrame,3,GBB.UpdateGroupList)
-	GBB.Tool.TabOnSelect(GroupBulletinBoardFrame,2,GBB.UpdateLfgTool)
-	
+	GBB.Tool.TabOnSelect(GroupBulletinBoardFrame,2,function()
+		GBB.LfgTool:UpdateBoardListings() -- optimistic update of listings if any residual search result data is present.
+		GBB.LfgTool.RefreshButton:GetScript("OnClick")() -- refresh search results
+	end)
 	GameTooltip:HookScript("OnTooltipSetUnit", hooked_createTooltip)
 		
 	print("|cFFFF1C1C Loaded: "..GetAddOnMetadata(TOCNAME, "Title") .." ".. GetAddOnMetadata(TOCNAME, "Version") .." by "..GetAddOnMetadata(TOCNAME, "Author"))

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -540,8 +540,6 @@ function GBB.Popup_Minimap(frame,showMinimapOptions)
 end
 
 function GBB.Init()
-	GroupBulletinBoardFrame_LfgFrame:Hide() -- todo: remove deprecated frame from xml
-	local GroupBulletinBoardFrame_LfgFrame = GBB.LfgTool.ScrollContainer -- use new frame
 	GroupBulletinBoardFrame:SetResizeBounds(400,170)	
 	GroupBulletinBoardFrame:SetClampedToScreen(true)
 	GBB.UserLevel=UnitLevel("player")
@@ -770,8 +768,8 @@ function GBB.Init()
 		if (serverType == Enum.SeasonID.SeasonOfDiscovery)
 		or (serverType == Enum.SeasonID.Fresh)
 		or (serverType == Enum.SeasonID.FreshHardcore)
-		then GBB.Tool.AddTab(GroupBulletinBoardFrame, GBB.L.TabLfg, GroupBulletinBoardFrame_LfgFrame);
-		else GroupBulletinBoardFrame_LfgFrame:Hide() end;
+		then GBB.Tool.AddTab(GroupBulletinBoardFrame, GBB.L.TabLfg, GBB.LfgTool.ScrollContainer);
+		else GBB.LfgTool.ScrollContainer:Hide() end;
 
 		-- Past group members tab. (Inactive and broken)
 		-- GBB.Tool.AddTab(GroupBulletinBoardFrame, GBB.L.TabGroup, GroupBulletinBoardFrame_GroupFrame);
@@ -780,8 +778,8 @@ function GBB.Init()
 		-- cata client for Hide all tabs except requests for the time being
 		GBB.Tool.AddTab(GroupBulletinBoardFrame, GBB.L.TabRequest, GroupBulletinBoardFrame_ScrollFrame);
 
-		-- GBB.Tool.AddTab(GroupBulletinBoardFrame, GBB.L.TabLfg, GroupBulletinBoardFrame_LfgFrame);
-		GroupBulletinBoardFrame_LfgFrame:Hide()
+		-- GBB.Tool.AddTab(GroupBulletinBoardFrame, GBB.L.TabLfg, GBB.LfgTool.ScrollContainer);
+		GBB.LfgTool.ScrollContainer:Hide()
 
 		-- GBB.Tool.AddTab(GroupBulletinBoardFrame, GBB.L.TabGroup, GroupBulletinBoardFrame_GroupFrame);
 		GroupBulletinBoardFrame_GroupFrame:Hide()

--- a/LFGBulletinBoard/GroupBulletinBoard.xml
+++ b/LFGBulletinBoard/GroupBulletinBoard.xml
@@ -214,49 +214,6 @@
 					</Frame>
 				</ScrollChild>
 			</ScrollFrame>
-
-
-			<!-- lfgframe -->
-			
-			<ScrollFrame name="GroupBulletinBoardFrame_LfgFrame" inherits="UIPanelScrollFrameTemplate">
-				<Frames>
-					<Frame name="$parentBackdrop" inherits="BackdropTemplate">
-						<Scripts>
-							<OnLoad>
-								self.backdropInfo = {
-									bgFile = "Interface\\TutorialFrame\\TutorialFrameBackground",
-									tile = true,
-									insets = {
-										left = -3,
-										right = -23,
-										top = -3,
-										bottom = -3
-									}
-								}
-								self:ApplyBackdrop()
-							</OnLoad>
-						</Scripts>
-					</Frame>
-				</Frames>
-				<Anchors>
-					<Anchor point="TOPLEFT">
-						<Offset>
-							<AbsDimension x="10" y="-30"/>
-						</Offset>						
-					</Anchor>				
-				</Anchors>
-				<Size>
-					<AbsDimension x="100" y="100"/>
-				</Size>
-				<ScrollChild>
-					<Frame name="GroupBulletinBoardFrame_LfgChildFrame">
-						<Size>
-							<AbsDimension x="100" y="100"/>
-						</Size>
-					</Frame>
-				</ScrollChild>
-			</ScrollFrame>
-
 			<!-- groupframe -->
 			
 			<ScrollingMessageFrame enableMouse="true" name="GroupBulletinBoardFrame_GroupFrame"  parentKey="MessageFrame" enableMouseClicks="true" >

--- a/LFGBulletinBoard/GroupBulletinBoard.xml
+++ b/LFGBulletinBoard/GroupBulletinBoard.xml
@@ -100,9 +100,7 @@
 					<Anchor point="RIGHT" relativeTo="$parentSettingsButton" relativePoint="LEFT"/>
 				</Anchors>
 				<Scripts>
-					<OnMouseDown>
-						GroupBulletinBoard_Addon.BtnRefresh(button )
-					</OnMouseDown>
+					<!-- see LfgToolList.lua -->
 				</Scripts>
 			</Button>
 

--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -20,5 +20,5 @@ RequestList.lua
 Options.lua
 GroupList.Lua
 GroupBulletinBoard.lua
-LfgToolList.lua
 GroupBulletinBoard.xml
+LfgToolList.lua

--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -4,7 +4,7 @@ local 	TOCNAME,GBB=...
 local MAXGROUP=500
 local LastUpdateTime = time()
 local requestNil={dungeon="NIL",start=0,last=0,name=""}
-
+local isCata = WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC
 local function requestSort_TOP_TOTAL (a,b)
 	if GBB.dungeonSort[a.dungeon] < GBB.dungeonSort[b.dungeon] then
 		return true
@@ -205,34 +205,40 @@ function GBB.GetLfgList()
 end
 
 function GBB.UpdateLfgTool()
-    if LFGListFrame and LFGListFrame.CategorySelection.selectedCategory == 120 then return end
-    if  LFGListFrame and LFGListFrame.CategorySelection.selectedCategory == nil then  
-        LFGListFrame.CategorySelection.selectedCategory = 2
-    end
+	-- named differently on cata/era
+	local LFGListFrame = isCata and _G.LFGListFrame or _G.LFGListingFrame
+	if isCata then
+		if LFGListFrame and LFGListFrame.CategorySelection.selectedCategory == 120 then return end
+		if  LFGListFrame and LFGListFrame.CategorySelection.selectedCategory == nil then
+			LFGListFrame.CategorySelection.selectedCategory = 2
+		end
 
-    LastUpdateTime = time()
-    GBB.LfgRequestList = {}
-    
-    local category = 2
-    if LFGListFrame and LFGListFrame.CategorySelection.selectedCategory ~= nil then 
-        category = LFGListFrame.CategorySelection.selectedCategory
-    end
+		LastUpdateTime = time()
+		GBB.LfgRequestList = {}
 
-	local activities = C_LFGList.GetAvailableActivities(category)
-	--C_LFGList.Search(category, activities)
-    if LFGListFrame and LFGListFrame.searching then return end
+		local category = 2
+		if LFGListFrame and LFGListFrame.CategorySelection.selectedCategory ~= nil then
+			category = LFGListFrame.CategorySelection.selectedCategory
+		end
 
-	GBB.GetLfgList()
-    GBB.LfgUpdateList()
+		local activities = C_LFGList.GetAvailableActivities(category)
+		--C_LFGList.Search(category, activities)
+		if LFGListFrame and LFGListFrame.searching then return end
+	end
+
+		GBB.GetLfgList()
+		GBB.LfgUpdateList()
 end
 
 function GBB.UpdateLfgToolNoSearch()
-    if LFGListFrame.CategorySelection.selectedCategory == 120 then return end
-    if  LFGListFrame.CategorySelection.selectedCategory == nil then  
-        LFGListFrame.CategorySelection.selectedCategory = 2
-    end
+	if isCata then
+		if LFGListFrame.CategorySelection.selectedCategory == 120 then return end
+		if  LFGListFrame.CategorySelection.selectedCategory == nil then
+			LFGListFrame.CategorySelection.selectedCategory = 2
+		end
+	end
 
-if LFGListFrame and LFGListFrame.searching then return end
+	if LFGListFrame and LFGListFrame.searching then return end
 
     GBB.LfgRequestList = {}
     GBB.GetLfgList()

--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -101,12 +101,14 @@ LFGTool.RefreshSpinner:SetPoint("RIGHT", LFGTool.RefreshButton, "LEFT", -2, 0)
 LFGTool.RefreshSpinner:Hide()
 
 local onSearchStart = function(categoryID)
+	LFGTool.searching = true
 	selectedCategoryID = categoryID
 	LFGTool.RefreshButton:Disable()
 	LFGTool.RefreshSpinner:Show()
 	LFGTool.CategoryButton.Dropdown:Disable()
 end
 local onSearchComplete = function()
+	LFGTool.searching = false
     LFGTool.RefreshButton:Enable()
     LFGTool.RefreshSpinner:Hide()
 	LFGTool.CategoryButton.Dropdown:Enable()
@@ -912,9 +914,13 @@ function LFGTool:UpdateRequestList()
 end
 ---Populates `requestList` with search results and updates the bulletin board view container
 function LFGTool:UpdateBoardListings()
-	if not LFGTool.ScrollContainer:IsVisible() then return; end
-	self:UpdateRequestList()
-	updateScrollViewData(self.ScrollContainer.scrollView, self.requestList)
+	if not LFGTool.ScrollContainer:IsVisible() then return end
+
+	if LFGTool.searching then -- use existing requests if update called mid search
+		if not LFGTool.requestList[1] then return; end
+	else LFGTool:UpdateRequestList() end -- otherwise, update the request list
+
+	updateScrollViewData(LFGTool.ScrollContainer.scrollView, LFGTool.requestList)
 	self.StatusText:SetText(string.format(GBB.L["msgLfgRequest"], SecondsToTime(time()-LastUpdateTime), self.numRequests))
 end
 function LFGTool:Load()

--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -94,13 +94,29 @@ do -- Setup category selection dropdown buttons
 		end
 	end);
 end
+-- LFGList searching spinner
+LFGTool.RefreshSpinner = CreateFrame("Frame", nil, LFGTool.RefreshButton, "LoadingSpinnerTemplate")
+LFGTool.RefreshSpinner:SetSize(25, 25)
+LFGTool.RefreshSpinner:SetPoint("RIGHT", LFGTool.RefreshButton, "LEFT", -2, 0)
+LFGTool.RefreshSpinner:Hide()
 
--- allows us to keep category up to date, with external/blizz calls to LFGList.Search
-hooksecurefunc(C_LFGList, "Search", function(categoryID)
+local onSearchStart = function(categoryID)
 	selectedCategoryID = categoryID
+	LFGTool.RefreshButton:Disable()
+	LFGTool.RefreshSpinner:Show()
+	LFGTool.CategoryButton.Dropdown:Disable()
+end
+local onSearchComplete = function()
+    LFGTool.RefreshButton:Enable()
+    LFGTool.RefreshSpinner:Hide()
+	LFGTool.CategoryButton.Dropdown:Enable()
 	LFGTool.CategoryButton.Dropdown:SignalUpdate()
+    LFGTool:UpdateBoardListings()
 	LastUpdateTime = time()
-end)
+end
+hooksecurefunc(C_LFGList, "Search", onSearchStart) -- keep state up to date, with external/blizz calls to LFGList.Search
+GBB.Tool.RegisterEvent("LFG_LIST_SEARCH_RESULTS_RECEIVED", onSearchComplete)
+GBB.Tool.RegisterEvent("LFG_LIST_SEARCH_FAILED", onSearchComplete)
 
 local RefreshButton_OnClick = function()
 	LFGList_DoCategorySearch(selectedCategoryID)

--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -54,6 +54,44 @@ local function requestSort_nTOP_nTOTAL (a,b)
 	return false
 end
 
+local function LFGSearch(categoryId)
+    local filterVal = 0
+    -- if categoryId == 2 then
+    --     filterVal = 1
+    -- end
+
+	local preferredFilters
+    local languages = C_LFGList.GetLanguageSearchFilter() or {};
+	-- include addon set languages
+	languages.enUS =languages.enUS or GBB.DB.TagsEnglish
+	languages.deDE =languages.deDE or GBB.DB.TagsGerman
+	languages.ruRU =languages.ruRU or GBB.DB.TagsRussian
+	languages.frFR =languages.frFR or GBB.DB.TagsFrench
+	languages.zhTW =languages.zhTW or GBB.DB.TagsZhtw
+	languages.zhCN =languages.zhCN or GBB.DB.TagsZhcn
+	languages.esES =languages.esES or GBB.DB.TagsSpanish
+	languages.esMX =languages.esMX or GBB.DB.TagsSpanish
+	languages.ptBR =languages.ptBR or GBB.DB.TagsPortuguese
+    C_LFGList.Search(categoryId, filterVal, preferredFilters, languages)
+end
+
+----------------------------------------------------
+local categoryIdx = 0
+local lfgCategories = {
+	2, -- Dungeons
+	114, -- Raids
+	116, -- Quests & Zones
+	118, -- PVP (not enabled in cata clients atm)
+	120, -- "Custom"
+}
+function GBB.BtnRefresh(button)
+	categoryIdx = math.fmod(categoryIdx, #lfgCategories) + 1
+	LFGSearch(lfgCategories[categoryIdx])
+end
+
+-- hack: set the refresh button parent to the lfg frame. hides the button when the "Tool Requests" tab is not selected
+GroupBulletinBoardFrameRefreshButton:SetParent(GroupBulletinBoardFrame_LfgFrame)
+
 local function WhoRequest(name)
 	--DEFAULT_CHAT_FRAME:AddMessage(GBB.MSGPREFIX .. string.format(GBB.L["msgStartWho"],name))
 	--DEFAULT_CHAT_FRAME.editBox:SetText("/who " .. name)
@@ -167,11 +205,11 @@ function GBB.GetLfgList()
                             local isRaid = GBB.RaidList[dungeon] ~= nil
             
                             if index==0 then
-                                local role, class, classLocalized, specLocalized = C_LFGList.GetSearchResultMemberInfo(searchResultData.searchResultID, 1);
+								local playerInfo = C_LFGList.GetSearchResultPlayerInfo(searchResultData.searchResultID, 1)
                                 local partyInfo = GBB.GetPartyInfo(searchResultData.searchResultID, searchResultData.numMembers)
                                 index=#GBB.LfgRequestList +1
                                 GBB.LfgRequestList[index]={}
-                                GBB.LfgRequestList[index].class=classLocalized
+                                GBB.LfgRequestList[index].class=playerInfo.classFilename
                                 GBB.LfgRequestList[index].partyInfo=partyInfo
                                 GBB.LfgRequestList[index].start=requestTime
                                 GBB.LfgRequestList[index].dungeon=dungeon

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -407,7 +407,7 @@ end
 ---@param leaderName string
 ---@param dungeonKey string
 ---@param isHeroic boolean?
-local function SendJoinRequestMessage(leaderName, dungeonKey, isHeroic)
+function GBB.SendJoinRequestMessage(leaderName, dungeonKey, isHeroic)
 	if not GBB.DB.EnableJoinRequestMessage then return end
 	local dungeon = GBB.dungeonNames[dungeonKey] or dungeonKey
 	local msg = GBB.DB.JoinRequestMessage
@@ -1050,7 +1050,7 @@ function GBB.ClickRequest(entry, button)
 			WhoRequest(req.name)
 			--SendWho( req.name )
 		elseif IsAltKeyDown() then
-			SendJoinRequestMessage(req.name, req.dungeon, req.IsHeroic)
+			GBB.SendJoinRequestMessage(req.name, req.dungeon, req.IsHeroic)
 		elseif IsControlKeyDown() then
 			InviteRequest(req.name)
 		else

--- a/LFGBulletinBoard/dungeons/classic.lua
+++ b/LFGBulletinBoard/dungeons/classic.lua
@@ -58,9 +58,7 @@ local LFGActivityIDs = {
     ["WC"] = 796,  -- Wailing Caverns
     ["DM"] = 799,  -- Deadmines
     ["SFK"] = 800,  -- Shadowfang Keep
-    ["BFD"] = not isSoD and 801 or 1604,  -- Blackfathom Deeps
     ["STK"] = 802, -- Stormwind Stockades
-    ["GNO"] = not isSoD and 803 or 1605,  -- Gnomeregan
     ["RFK"] = 804,  -- Razorfen Kraul
     ["SM2"] = 5555,  -- Scarlet Monastery (used for the combine dungeons option) *spoofed*
     ["SMG"] = 805,  -- Scarlet Monastery - Graveyard
@@ -71,7 +69,6 @@ local LFGActivityIDs = {
     ["ULD"] = 807,  -- Uldaman
     ["ZF"] = 808,  -- Zul'Farrak
     ["MAR"] = 809,  -- Maraudon
-    ["ST"] = not isSoD and 810 or 1606,  -- Sunken Temple
     ["BRD"] = 811,  -- Blackrock Depths
     ["DM2"] = 6666,  -- Dire Maul (used for the combine dungeons option) *spoofed*
     ["DME"] = 813,  -- Dire Maul - East
@@ -82,17 +79,21 @@ local LFGActivityIDs = {
     ["LBRS"] = 812,  -- Lower Blackrock Spire
     ["UBRS"] = 837,  -- Upper Blackrock Spire
     -- Raids
-    ["ONY"] = 838,  -- Onyxia
     ["ZG"] = 836,  -- Zul'Gurub
-    ["MC"] = 839,  -- Molten Core
     ["BWL"] = 840,  -- Blackwing Lair
-    ["AQ20"] = 842,  -- Ahn'Qiraj Ruins
-    ["AQ40"] = 843,  -- Ahn'Qiraj Temple
     ["NAXX"] = 841,  -- Naxxramas
     -- Battlegrounds
     ["WSG"] = 924, -- Warsong Gulch [919-924]
     ["AB"] = 930,  -- Arathi Basin [926-930]
     ["AV"] = 932,  -- Alterac Valley
+    -- SoD/Classic augmented
+    ["BFD"] = not isSoD and 801 or 1604,  -- Blackfathom Deeps
+    ["GNO"] = not isSoD and 803 or 1605,  -- Gnomeregan
+    ["ST"] = not isSoD and 810 or 1606,  -- Sunken Temple
+    ["ONY"] = not isSoD and 838 or 1612,  -- Onyxia
+    ["MC"] = not isSoD and 839 or 1613,  -- Molten Core
+    ["AQ20"] = not isSoD and 842 or 1614,  -- Ahn'Qiraj Ruins
+    ["AQ40"] = not isSoD and 843 or 1615,  -- Ahn'Qiraj Temple
     -- SoD Specific
     ["DFC"] = isSoD and 1607 or nil, -- Demon Fall Canyon
     ["AZGS"] = isSoD and 1608 or nil, -- Storm Cliffs (Azuregoes)
@@ -229,6 +230,22 @@ function addon.GetDungeonLevelRanges()
     return cachedLevelRanges
 end
 
+local activityRemap = {
+    [919] = 924, -- WSG 10 - 19
+    [920] = 924, -- 20 - 29
+    [921] = 924, -- 30 - 39
+    [922] = 924, -- 40 - 49
+    [923] = 924, -- 50 - 59
+    [926] = 930, -- AB 20 - 29
+    [927] = 930, -- 30 - 39
+    [928] = 930, -- 40 - 49
+    [929] = 930, -- 50 - 59
+    [1603] = 816, -- Link STR live to STR undead (see infoOverrides table)
+}
+---@param opts {activityID: number}
+function addon.GetDungeonKeyByID(opts)
+        return idToDungeonKey[activityRemap[opts.activityID] or opts.activityID]
+end
 addon.rawClassicDungeonInfo = infoByTagKey
 addon.Enum.DungeonType = DungeonType
 addon.Enum.Expansions = Expansions


### PR DESCRIPTION
**Related Issues**: 
 - #323 
 
**In this PR**:

This pull request includes significant changes to the `LFGToolList.lua` module including:
- removing old scroll and entry frames and integrating new ones
- updating the requestList generation/parsing to respect the activityID system.
- addressing limitations around the `C_LFGList.Search` API

### Removal of Deprecated LFG Functionalities:
* [`LFGBulletinBoard/GroupBulletinBoard.lua`](diffhunk://#diff-93cc48d022994422e1d92249731e5fafce9a04ed82e7da18358109de568a7d1aL323-L335): Removed old LFG frame resizing and refresh button functions (`GBB.ResizeFrameList`, `GBB.BtnRefresh`). [[1]](diffhunk://#diff-93cc48d022994422e1d92249731e5fafce9a04ed82e7da18358109de568a7d1aL323-L335) [[2]](diffhunk://#diff-93cc48d022994422e1d92249731e5fafce9a04ed82e7da18358109de568a7d1aL368-L371)
* [`LFGBulletinBoard/GroupBulletinBoard.xml`](diffhunk://#diff-22537a6c2a6ecb8d58bd01b9d5297124da79e6da11602c8d25867f375fdc647bL217-L259): Removed XML definitions for old LFG frames and their related scripts.

### Addition of New LFG Tool Integrations:
* [`LFGBulletinBoard/GroupBulletinBoard.lua`](diffhunk://#diff-93cc48d022994422e1d92249731e5fafce9a04ed82e7da18358109de568a7d1aR593-L610): Integrated new LFG tool module loading and updated tab setup to include the new LFG tool. [[1]](diffhunk://#diff-93cc48d022994422e1d92249731e5fafce9a04ed82e7da18358109de568a7d1aR593-L610) [[2]](diffhunk://#diff-93cc48d022994422e1d92249731e5fafce9a04ed82e7da18358109de568a7d1aL763-R780)
* [`LFGBulletinBoard/GroupBulletinBoard.lua`](diffhunk://#diff-93cc48d022994422e1d92249731e5fafce9a04ed82e7da18358109de568a7d1aL796-R798): Added a function to update LFG tool listings optimistically when the LFG tab is selected.

### Updates to Dungeon Activity IDs:
* [`LFGBulletinBoard/dungeons/classic.lua`](diffhunk://#diff-5d7e7ffbd2b9814ff6e09bb8dfd26e2bab8ac2805e1aa501cc800336bf882b13L61-L63): Updated LFG activity IDs for dungeons and raids to support new season types. [[1]](diffhunk://#diff-5d7e7ffbd2b9814ff6e09bb8dfd26e2bab8ac2805e1aa501cc800336bf882b13L61-L63) [[2]](diffhunk://#diff-5d7e7ffbd2b9814ff6e09bb8dfd26e2bab8ac2805e1aa501cc800336bf882b13L85-R96)
* [`LFGBulletinBoard/dungeons/classic.lua`](diffhunk://#diff-5d7e7ffbd2b9814ff6e09bb8dfd26e2bab8ac2805e1aa501cc800336bf882b13R233-R248): Added a remap function for dungeon activity IDs to handle different versions and expansions.


**Images:**
![WowClassic_chbCNMyhEA](https://github.com/user-attachments/assets/2784f37d-42fa-49e5-9f6f-a82f46ba50b8)

**Known Issues**:
- There is a currently a visual bug where, when initially created, the request entry frames will have text that is overfilling its containers.
  - ![WowClassic_T8e5CG7ZkT](https://github.com/user-attachments/assets/bcbe535c-8676-487e-99bd-4fe865a4e604)
  - To fix, scroll the entries out of view, or Collapse/Uncollapse all the categories
