### PR TITLE
[feat][ui]: disable child option widgets when parent setting is disabled

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -475,9 +475,13 @@ local function hooked_createTooltip(self)
 	if (name) and (unit) and UnitIsPlayer(unit) then
 	
 		if GBB.DB.EnableGuild then
-			local guildName = GetGuildInfo(unit)
+			local guildName, guildRank = GetGuildInfo(unit)
 			if guildName then
-				self:AddLine(Mixin(ColorMixin, GBB.DB.ColorGuild):WrapTextInColorCode(("<%s>"):format(guildName)))
+				self:AddLine(Mixin(ColorMixin, GBB.DB.ColorGuild):WrapTextInColorCode(
+					(GBB.DB.EnableGuildRank and guildRank)
+						and ("<%s> - %s"):format(guildName, guildRank)
+						or ("<%s>"):format(guildName)
+				));
 			end
 		end
 

--- a/LFGBulletinBoard/Localization.lua
+++ b/LFGBulletinBoard/Localization.lua
@@ -29,6 +29,8 @@ local preLocalizedFallbacks = {
 		local localizedName = C_ChatInfo.GetChannelShortcutForChannelID(lfgChannelID)
 		return localizedName
 	end)(),
+	-- default global string includes an unwanted colon at the end
+	ADD_GUILDRANK_LABEL = ADD_GUILDRANK_LABEL:gsub("%p", ""),
 	["world_channel"] = CHANNEL_CATEGORY_WORLD,
 	["GuildChannel"] = GUILD_CHAT,
 	["msgLevelRange"] = LFD_LEVEL_FORMAT_RANGE:gsub("%(", ("(%s "):format(LEVEL)),

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -241,7 +241,6 @@ local function GenerateExpansionPanel(expansionID)
 				if newValue == true and mutualBox:GetSavedValue() == true then
 					mutualBox:SetSavedValue(false)
 				end
-				updatedBox:SetChecked(newValue)
 			end
 		end
 		heroicOnly:OnSavedVarUpdate(exclusiveUpdateHandler(heroicOnly, normalOnly))
@@ -327,7 +326,6 @@ function GBB.OptionsInit ()
 		local updateHook = function(useLibDBIcon)
 			lockDistCheckbox:SetChecked(useLibDBIcon or  GBB.DB.MinimapButton.lockDistance)
 			lockDistCheckbox:SetEnabled(not useLibDBIcon)
-			lockDistCheckbox.Text:SetTextColor(unpack(useLibDBIcon and {GRAY_FONT_COLOR:GetRGB()} or {WHITE_FONT_COLOR:GetRGB()}))
 		end
 		GBB.OptionsBuilder.GetSavedVarHandle(GBB.DB.MinimapButton, 'UseLibDBIcon'):AddUpdateHook(updateHook);
 		updateHook(GBB.DB.MinimapButton.UseLibDBIcon) -- run once to sync the checkbox state.
@@ -373,7 +371,6 @@ function GBB.OptionsInit ()
 			if selection == true -- both options can be  toggled off at the same time, but not on.
 			and mutualBox:GetSavedValue() == true
 			then mutualBox:SetSavedValue(false) end;
-			updatedBox:SetChecked(selection)
 		end
 	end
 	chatStyleBox:OnSavedVarUpdate(exclusiveUpdateHandler(chatStyleBox, compactStyleBox))
@@ -406,12 +403,8 @@ function GBB.OptionsInit ()
 				editbox:SetText(GBB.L.JOIN_REQUEST_MESSAGE)
 			end
 		end)
-		local ogCheckboxFunc = checkbox.updateFunc -- save reference since overwriting with OnSavedVarUpdate call.
 		local updateWidgets = function(value)
-			if ogCheckboxFunc then ogCheckboxFunc(value) end
 			editbox:SetEnabled(value)
-			editbox:SetTextColor((value and WHITE_FONT_COLOR or GRAY_FONT_COLOR):GetRGB())
-			checkbox.Text:SetTextColor((value and NORMAL_FONT_COLOR or GRAY_FONT_COLOR):GetRGB())
 		end
 		updateWidgets(checkbox:GetSavedValue())
 		checkbox:OnSavedVarUpdate(updateWidgets)


### PR DESCRIPTION
- will gray out sub-options when the parent option is disabled basically.    
- should help improve the eye-soreness of the addon main settings panel.
- additionally, reintroduces option to include guild rank in guild tooltip.

**related issues**
 - #333 
 
**images**
![WowClassic_n361PtSCxT](https://github.com/user-attachments/assets/6cc0dbb2-d65d-495f-ae24-28e321bd49d5)

![image](https://github.com/user-attachments/assets/53e0e968-bca9-4417-a91f-10559a9276c5)

