### PR TITLE
[misc][hotfix] Minor updates and LFGTool ui nit hotfixes

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -550,6 +550,8 @@ function GBB.Init()
 	GBB.UserLevel=UnitLevel("player")
 	GBB.UserName=(UnitFullName("player"))
 	GBB.ServerName=GetRealmName()
+	GBB.RealLevel = {} -- recently seen player levels
+	GBB.RealLevel[GBB.UserName] = GBB.UserLevel
 
 	-- Initalize options
 	if not GroupBulletinBoardDB then GroupBulletinBoardDB = {} end -- fresh DB
@@ -754,13 +756,11 @@ function GBB.Init()
 		end
 	)
 	GBB.Tool.EnableMoving(GroupBulletinBoardFrame,GBB.SaveAnchors)
-	
+
 	GBB.PatternWho1=GBB.Tool.CreatePattern(WHO_LIST_FORMAT )
 	GBB.PatternWho2=GBB.Tool.CreatePattern(WHO_LIST_GUILD_FORMAT )
 	GBB.PatternOnline=GBB.Tool.CreatePattern(ERR_FRIEND_ONLINE_SS)
-	GBB.RealLevel={}
-	GBB.RealLevel[GBB.UserName]=GBB.UserLevel
-	
+
 	GroupBulletinBoardFrameTitle:SetText(string.format(GBB.TxtEscapePicture,GBB.MiniIcon).." ".. GBB.Title)
 	
 	GBB.Initalized=true

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -353,10 +353,16 @@ end
 
 function GBB.BtnSettings(button )
 	if button == "LeftButton" then
-		GBB.OptionsBuilder.OpenCategoryPanel(1)
+		local shouldOpen = GBB.PopupDynamic:Wipe("SettingsButtonMenu");
+		if shouldOpen then
+			GBB.PopupDynamic:AddItem(FILTERS, false, GBB.OptionsBuilder.OpenCategoryPanel, 2)
+			GBB.PopupDynamic:AddItem(ALL_SETTINGS, false, GBB.OptionsBuilder.OpenCategoryPanel, 1)
+			GBB.PopupDynamic:AddItem(GBB.L["BtnCancel"],false)
+			GBB.PopupDynamic:Show(GroupBulletinBoardFrameSettingsButton,0,0)
+		end
+		PlaySound(SOUNDKIT.IG_MAINMENU_OPTION, "SFX")
 	else
 		GBB.Popup_Minimap("cursor",false)
-		--GBB.Options.Open(1)
 	end
 end
 --------------------------------------------------------------------------------
@@ -753,6 +759,8 @@ function GBB.Init()
 	GBB.Initalized=true
 	
 	GBB.PopupDynamic=GBB.Tool.CreatePopup(GBB.OptionsUpdate)
+	-- hack: hide settings button popup whenever the board frame is hidden
+	GroupBulletinBoardFrameSettingsButton:HookScript("OnHide", function() GBB.PopupDynamic:Wipe("SettingsButtonMenu") end)
 	GBB.InitGroupList()
 
 	if isClassicEra then -- setup tabs

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -753,6 +753,7 @@ function GBB.Init()
 		GBB.ResizeFrameList()
 		GBB.SaveAnchors()
 		GBB.UpdateList()
+		GBB.LfgTool.OnFrameResized()
 		end
 	)
 	GBB.Tool.EnableMoving(GroupBulletinBoardFrame,GBB.SaveAnchors)

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -600,6 +600,15 @@ function GBB.Init()
 	-- Must do before the call to `GBB.CreateTagList()` below
 	GBB.SyncCustomFilterTags(GBB.dungeonTagsLoc);
 
+	--- Track state for a headers collapsed between both the chat and tool request tabs.
+	GBB.FoldedDungeons = setmetatable({}, {
+		-- default to `GBB.DB.HeadersStartFolded` instead of nil when key first seen
+		__index = function(self, key)
+			rawset(self, key, GBB.DB.HeadersStartFolded)
+			return GBB.DB.HeadersStartFolded
+		end
+	});
+
 	-- Load LFGList tool module
 	GBB.LfgTool:Load()
 
@@ -607,8 +616,6 @@ function GBB.Init()
 	GBB.RequestList={}
 	GBB.FramesEntries={}
 
-	GBB.FoldedDungeons={}
-	
 	-- Timer-Stuff
 	GBB.MAXTIME=time() +60*60*24*365 --add a year!
 	
@@ -967,4 +974,3 @@ function GBB.OnUpdate(elapsed)
 		end;
 	end
 end
-

--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -31,7 +31,7 @@ local LFGLIST_CATEGORY_IDS = { -- alternatively, use C_LFGList.GetAvailableCateg
 	2, -- Dungeons
 	114, -- Raids
 	116, -- Quests & Zones
-	118, -- PVP (not enabled in cata clients atm)
+	-- 118, -- PVP (not enabled in any clients atm)
 	120, -- "Custom"
 }
 

--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -1030,6 +1030,7 @@ function LFGTool:UpdateRequestList()
             if searchResultData.comment ~= nil and string.len(searchResultData.comment) > 2 then
                 message = searchResultData.comment
             end
+			GBB.RealLevel[leaderInfo.name] = leaderInfo.level
 			for _, activityID in pairs(searchResultData.activityIDs) do
 				local activityInfo = C_LFGList.GetActivityInfoTable(activityID)
 				-- DevTool:AddData(activityInfo, resultID)

--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -1022,7 +1022,7 @@ function LFGTool:UpdateRequestList()
 	for _, resultID in ipairs(results) do
         local searchResultData = C_LFGList.GetSearchResultInfo(resultID)
 		local leaderInfo = C_LFGList.GetSearchResultLeaderInfo(resultID)
-        if not searchResultData.isDelisted and leaderInfo then
+        if not searchResultData.isDelisted and leaderInfo and leaderInfo.name then
 			local isSolo = searchResultData.numMembers == 1
 			local isSelf = leaderInfo.name == UnitNameUnmodified("player")
             local listingTimestamp = time() - searchResultData.age
@@ -1043,7 +1043,7 @@ function LFGTool:UpdateRequestList()
 				---@class LFGToolRequestData todo: cleanup unnecessary fields
 				local entry = {
 					-- fields copied from previous request gathering method
-					name = searchResultData.leaderName or UNKNOWN,
+					name = leaderInfo.name,
 					message = message,
 					class = leaderInfo.classFilename,
 					start = listingTimestamp,

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -154,12 +154,6 @@ local function CreateHeader(scrollPos, dungeon)
 			categoryName = EASY_DIFFICULTY_COLOR:WrapTextInColorCode(categoryName)
 		end
 	end
-	
-	-- Initialize this value now so we can (un)fold only existing entries later
-	-- while still allowing new headers to follow the HeadersStartFolded setting
-	if GBB.FoldedDungeons[dungeon] == nil then
-		GBB.FoldedDungeons[dungeon]=GBB.DB.HeadersStartFolded
-	end
 
 	header.Name:SetText(("%s %s"):format(categoryName, levelRange))
 	header.Name:SetFontObject(GBB.DB.FontSize)


### PR DESCRIPTION
## In this PR
**[feat][refactor]: settings button now toggles a simple dropdown**

- allows easier access to the filter settings

![sample_img](https://i.imgur.com/26ctjEA.png)


**[hotfix]: sync folded/collapsed headers between chat and tool requests**

- bulletin board headers folded on the chat requests tab should remain folded when switching to the tool requests tab
- this hacky solution can be removed whenever i move the chat requests tab over to the same scrollbox/dataprovider api.


**[hotfix]: require `name` when generating request list entries for `LFGTool`**

- prevents "Unknown" players from appearing in the request list


**[feat]: share player level info from Tool Request with Chat requests**



**[dev][minor]: use named constants for data provider method arguments**

**[bugfix]: correct template name for "WowScrollBoxList"**


**[perf]: cleanup scroll view invalidations related to `Sort` calls**

- results in less internal calls to the a full update of the scroll view by way of batching updates before invalidating.


**[hotfix][ui]: fix issues with frames not resizing correctly within LFGTool**

- scroll element frames will now have correct size after initial load and after main addon frame resizes

**[hotfix]: remove `PvP` category from LFGTool dropdown options**

- This category is also not currently enabled in classic era (though the search api doesnt seem to care)
