### PR TITLE
[refactor]: more minor ui updates around LFGTool

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -802,6 +802,17 @@ function GBB.Init()
 			GBB.LfgTool:UpdateBoardListings() -- optimistic update of listings if any residual search data is present.
 			GBB.LfgTool.RefreshButton:GetScript("OnClick")() -- refresh search results
 		end)
+		-- only enable the tool tab whenever the player gains access to blizz LFGTool
+		local isTabEnabledYet = false
+		local trySetEnabled = function()
+			if not isTabEnabledYet then
+				local shouldEnable = C_LFGInfo.CanPlayerUsePremadeGroup();
+				GBB.Tool.SetTabEnabled(GroupBulletinBoardFrame, TabEnum.LFGTool, shouldEnable)
+				isTabEnabledYet = shouldEnable
+			end
+		end
+		GroupBulletinBoardFrame:HookScript("OnShow", trySetEnabled);
+		GBB.Tool.RegisterEvent("PLAYER_LEVEL_CHANGED", trySetEnabled);
 	else GBB.LfgTool.ScrollContainer:Hide() end;
 
 	if TabEnum.RecentPlayers then

--- a/LFGBulletinBoard/GroupList.lua
+++ b/LFGBulletinBoard/GroupList.lua
@@ -111,7 +111,9 @@ function GBB.UpdateGroupList()
 		table.sort(GBB.DBChar.GroupList,function(a,b) return a.lastSeen<b.lastSeen end)	
 	end
 		
-	if not GroupBulletinBoardFrame:IsVisible() or GBB.Tool.GetSelectedTab(GroupBulletinBoardFrame)~=3 then
+	if not GroupBulletinBoardFrame:IsVisible()
+	or GBB.GetSelectedTab() ~= GBB.Enum.Tabs.RecentPlayers
+	then
 		return
 	end
 	GBB.EditNote(nil)

--- a/LFGBulletinBoard/LibGPIToolBox.lua
+++ b/LFGBulletinBoard/LibGPIToolBox.lua
@@ -621,7 +621,10 @@ function Tool.GetSelectedTab(frame)
 	end
 	return 0
 end
-	
+function Tool.SetTabEnabled(frame, id, shouldEnable)
+	if not (id and frame.Tabs and frame.Tabs[id]) then return end;
+	PanelTemplates_SetTabEnabled(frame, id, shouldEnable)
+end
 function Tool.AddTab(frame,name,tabFrame,combatlockdown)
 	local frameName
 	


### PR DESCRIPTION
## In this PR:
**[refactor]: use C_LFGList API to determine available LFGTool categories**

Instead of manually enabling/disabling categories from the hardcoded table.
- enum table reflecting possible values added for source readability.
- note: the `C_LFGList.GetAvailableCategories` api can return an empty table early in the load process.
  - todo: instead of rebuilding the menu every `OnShow` for the bulletin board, rebuild only when C_LFGList.GetAvailableCategories returns new values


**[refactor][dev]: set up enumerated table for managing the different Tabs**

- named them ChatRequests, RecentPlayers, and LFGTool (for the RequestList, GroupList, and LfgToolList respectively)


**[refactor]: disable `LFGTool` for characters who dont have access to it yet**

- note: "disabled" as in; its still is visible and exists its just not clickable.
- players arent able to use the blizzard lfg tool until lvl 10
