### PR TITLE
[refactor][fix]: update `LFGTool` board whenever its container frame is shown

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -799,7 +799,6 @@ function GBB.Init()
 
 	if TabEnum.LFGTool then
 		GBB.Tool.TabOnSelect(GroupBulletinBoardFrame, TabEnum.LFGTool, function()
-			GBB.LfgTool:UpdateBoardListings() -- optimistic update of listings if any residual search data is present.
 			GBB.LfgTool.RefreshButton:GetScript("OnClick")() -- refresh search results
 		end)
 		-- only enable the tool tab whenever the player gains access to blizz LFGTool


### PR DESCRIPTION
- more permanently addresses a previous hotfix around sharing collapsed headers between the LFGTool and Chat Request tabs in #338 
- fixes an issue where when the addon board was closed and re-oppend while in the LFGtool tab, it would show stale entries.