### PR TITLE
[fix][ui]: fix a minor UI issue in LFGTool entry frames

### DIFF
--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -660,6 +660,7 @@ local function InitializeEntryItem(entry, node)
 			-- request message
 			self.Message:SetFontObject(GBB.DB.FontSize)
 			self.Message:SetMaxLines(GBB.DB.DontTrunicate and 99 or 1)
+			self.Message:SetWordWrap(GBB.DB.DontTrunicate and true or false)
 			self.Message:SetJustifyV("MIDDLE")
 			self.Message:ClearAllPoints() -- incase swapped to 2-line mode
 			-- dummy text to calculate normalized line height (icons are the biggest characters in any message)


### PR DESCRIPTION
Fixes an issue when not using the "Dont Truncate Messages" options.
The "role" textures for LFGTool entries would occasionally show up in erroneous positions, such as overlapping with other entries. (see image)

![image](https://github.com/user-attachments/assets/764f154d-837f-400c-a6d6-3def4672741b)
