### PR TITLE
[fix][refactors]: Fix taint issues related `UIDropDownMenu` api usage

### DIFF
--- a/LFGBulletinBoard/Chat.lua
+++ b/LFGBulletinBoard/Chat.lua
@@ -145,24 +145,3 @@ function GBB.Announce()
 		GroupBulletinBoardFrameAnnounceMsg:ClearFocus()
 	end
 end
-
-function GBB.CreateChannelPulldown (frame, level, menuList)
-	if level~=1 then return end
-	local t= GBB.PhraseChannelList(GetChannelList())
-	
-	local info = UIDropDownMenu_CreateInfo()
- 
-	
-	for i,channel in pairs(t) do
-		info.text =  i..". "..channel.name
-		info.checked = (channel.name == GBB.DB.AnnounceChannel)
-		info.disabled = channel.hidden
-		info.arg1 = i
-		info.arg2 = channel.name
-		info.func = function(self, arg1, arg2, checked)
-				GBB.DB.AnnounceChannel=arg2
-				GroupBulletinBoardFrameSelectChannel:SetText(arg2)
-			end
-		UIDropDownMenu_AddButton(info)
-	end
-end

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -350,7 +350,7 @@ function GBB.BtnSettings(button )
 		if shouldOpen then
 			GBB.PopupDynamic:AddItem(FILTERS, false, GBB.OptionsBuilder.OpenCategoryPanel, 2)
 			GBB.PopupDynamic:AddItem(ALL_SETTINGS, false, GBB.OptionsBuilder.OpenCategoryPanel, 1)
-			GBB.PopupDynamic:AddItem(GBB.L["BtnCancel"],false)
+			GBB.PopupDynamic:AddItem(GBB.L["BtnCancel"], false, nil, nil, nil, true)
 			GBB.PopupDynamic:Show(GroupBulletinBoardFrameSettingsButton,0,0)
 		end
 		PlaySound(SOUNDKIT.IG_MAINMENU_OPTION, "SFX")
@@ -532,7 +532,7 @@ function GBB.Popup_Minimap(frame,showMinimapOptions)
 		end
 	end
 	GBB.PopupDynamic:AddItem("",true)
-	GBB.PopupDynamic:AddItem(GBB.L["BtnCancel"],false)
+	GBB.PopupDynamic:AddItem(GBB.L["BtnCancel"], false, nil, nil, nil, true)
 		
 	GBB.PopupDynamic:Show(frame,0,0)
 end

--- a/LFGBulletinBoard/GroupBulletinBoard.xml
+++ b/LFGBulletinBoard/GroupBulletinBoard.xml
@@ -105,7 +105,10 @@
 			</Button>
 
 			<!-- announcebox -->
-			<Button name="$parentSelectChannel" inherits="UIPanelButtonTemplate" text="channel">
+			<DropdownButton name="$parentSelectChannel" inherits="UIPanelButtonTemplate" text="channel" mixin="WowStyle1DropdownMixin">
+				<KeyValues>
+					<KeyValue key="menuMixin" value="MenuStyle2Mixin" type="global"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="BOTTOMLEFT" relativePoint="BOTTOMLEFT" relativeTo="$parent" >
 						<Offset>
@@ -114,12 +117,7 @@
 					</Anchor>
 				</Anchors>
 				<Size><AbsDimension x="150" y="20" /></Size>
-				<Scripts>
-					<OnClick>
-						GroupBulletinBoard_Addon.BtnSelectChannel()
-					</OnClick>
-				</Scripts>
-			</Button>
+			</DropdownButton>
 			
 			<Button name="$parentAnnounce" inherits="UIPanelButtonTemplate" text="Post">
 				<Anchors>

--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -321,16 +321,16 @@ local function createMenu(DungeonID,req) -- shared right-click menu for headers 
 		return
 	end
 	if req then
-		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnWho"],req.name),false,WhoRequest,req.name)
-		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnWhisper"],req.name),false,WhisperRequest,req.name)
-		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnInvite"],req.name),false,InviteRequest,req.name)
-		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnIgnore"],req.name),false,IgnoreRequest,req.name)
+		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnWho"],req.name),false,WhoRequest,req.name,nil,true)
+		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnWhisper"],req.name),false,WhisperRequest,req.name,nil,true)
+		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnInvite"],req.name),false,InviteRequest,req.name,nil,true)
+		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnIgnore"],req.name),false,IgnoreRequest,req.name,nil,true)
 		GBB.PopupDynamic:AddItem("",true)
 	end
 	if DungeonID then
-		GBB.PopupDynamic:AddItem(GBB.L["BtnFold"], false, toggleHeaderCollapseByKey, DungeonID)
-		GBB.PopupDynamic:AddItem(GBB.L["BtnFoldAll"], false, setAllHeadersCollapsed, true)
-		GBB.PopupDynamic:AddItem(GBB.L["BtnUnFoldAll"], false, setAllHeadersCollapsed, false)
+		GBB.PopupDynamic:AddItem(GBB.L["BtnFold"], false, toggleHeaderCollapseByKey, DungeonID, nil, true)
+		GBB.PopupDynamic:AddItem(GBB.L["BtnFoldAll"], false, setAllHeadersCollapsed, true, nil, true)
+		GBB.PopupDynamic:AddItem(GBB.L["BtnUnFoldAll"], false, setAllHeadersCollapsed, false, nil, true)
 		GBB.PopupDynamic:AddItem("",true)
 	end
 	GBB.PopupDynamic:AddItem(GBB.L["CboxShowTotalTime"],false,GBB.DB,"ShowTotalTime")
@@ -345,7 +345,7 @@ local function createMenu(DungeonID,req) -- shared right-click menu for headers 
 	GBB.PopupDynamic:AddItem(GBB.L["CboxRemoveRealm"],false,GBB.DB,"RemoveRealm")
 	GBB.PopupDynamic:AddItem("",true)
 	GBB.PopupDynamic:AddItem(SETTINGS, false, GBB.OptionsBuilder.OpenCategoryPanel, 1)
-	GBB.PopupDynamic:AddItem(GBB.L["BtnCancel"],false)
+	GBB.PopupDynamic:AddItem(GBB.L["BtnCancel"], false, nil, nil, nil, true)
 	GBB.PopupDynamic:Show()
 end
 --------------------------------------------------------------------------------

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -258,8 +258,8 @@ local function GenerateExpansionPanel(expansionID)
 		allFilterSetChecked(false)
 	end)
 
+	GBB.OptionsBuilder.AddRadioDropdownToCurrentPanel(GBB.DB,"InviteRole", "DPS", {"DPS", "Tank", "Healer"})
 	-- Role Filters
-	GBB.OptionsBuilder.AddDropdownToCurrentPanel(GBB.DB,"InviteRole", "DPS", {"DPS", "Tank", "Healer"})
 	GBB.OptionsBuilder.EndInLine()
 	
 	-- Chat Channel Filters (only show for current xpac)
@@ -336,7 +336,7 @@ function GBB.OptionsInit ()
 	CheckBox("HeadersStartFolded",false)
 	GBB.OptionsBuilder.AddSpacerToPanel()
 	GBB.OptionsBuilder.AddTextToCurrentPanel(FONT_SIZE, -20)
-	GBB.OptionsBuilder.AddDropdownToCurrentPanel(GBB.DB,"FontSize", "GameFontNormal", {"GameFontNormalSmall", "GameFontNormal", "GameFontNormalLarge"}) 
+	GBB.OptionsBuilder.AddRadioDropdownToCurrentPanel(GBB.DB,"FontSize", "GameFontNormal", {"GameFontNormalSmall", "GameFontNormal", "GameFontNormalLarge"})
 
 	CheckBox("CombineSubDungeons",false)
 	CheckBox("IsolateTravelServices",true)

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -971,16 +971,16 @@ local function createMenu(DungeonID,req)
 		return
 	end
 	if req then
-		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnWho"],req.name),false,WhoRequest,req.name)
-		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnWhisper"],req.name),false,WhisperRequest,req.name)
-		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnInvite"],req.name),false,InviteRequest,req.name)
-		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnIgnore"],req.name),false,IgnoreRequest,req.name)
+		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnWho"],req.name),false,WhoRequest,req.name,nil,true)
+		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnWhisper"],req.name),false,WhisperRequest,req.name,nil,true)
+		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnInvite"],req.name),false,InviteRequest,req.name,nil,true)
+		GBB.PopupDynamic:AddItem(string.format(GBB.L["BtnIgnore"],req.name),false,IgnoreRequest,req.name,nil,true)
 		GBB.PopupDynamic:AddItem("",true)
 	end
 	if DungeonID then
-		GBB.PopupDynamic:AddItem(GBB.L["BtnFold"], false,GBB.FoldedDungeons,DungeonID)
-		GBB.PopupDynamic:AddItem(GBB.L["BtnFoldAll"], false,GBB.FoldAllDungeon)
-		GBB.PopupDynamic:AddItem(GBB.L["BtnUnFoldAll"], false,GBB.UnfoldAllDungeon)
+		GBB.PopupDynamic:AddItem(GBB.L["BtnFold"], false,GBB.FoldedDungeons,DungeonID, nil, true)
+		GBB.PopupDynamic:AddItem(GBB.L["BtnFoldAll"], false,GBB.FoldAllDungeon, nil, true)
+		GBB.PopupDynamic:AddItem(GBB.L["BtnUnFoldAll"], false,GBB.UnfoldAllDungeon, nil, true)
 		GBB.PopupDynamic:AddItem("",true)
 	end
 	GBB.PopupDynamic:AddItem(GBB.L["CboxShowTotalTime"],false,GBB.DB,"ShowTotalTime")
@@ -997,7 +997,7 @@ local function createMenu(DungeonID,req)
 	GBB.PopupDynamic:AddItem(SETTINGS, false, GBB.OptionsBuilder.OpenCategoryPanel, 1)
 	-- todo: Open to filter settings to expac related to DungeonID
 	GBB.PopupDynamic:AddItem(FILTERS, false, GBB.OptionsBuilder.OpenCategoryPanel, 2)
-	GBB.PopupDynamic:AddItem(GBB.L["BtnCancel"],false)
+	GBB.PopupDynamic:AddItem(GBB.L["BtnCancel"], false, nil, nil, nil, true)
 	GBB.PopupDynamic:Show()
 end
 


### PR DESCRIPTION
### In this PR

**[refactor]: migrate settings panel dropdowns to the new dropdown api**

- removes usage of deprecated UIDropDownMenu api
- this change should prevent any settings panel dropdowns from tainting ui

**[refactor]: migrate announcement channel selection dropdown to new API**

- similar to settings panel changes.

**[refactor][hotfix]: implement `TaintLess.xml` style cleanup for touched DropDownList buttons**
- Implementation of fixes mentioned in #344 
- This prevents *most* taint errors while allowing us use the `UIDropDownMenu`.
- This is a temporary solution to rewriting the whole `Tool.CreatePopup` system to support the new menuGenerator APIs.
- note: the `PopupDyanmic` frame is hard to re-create using the new API's because they dont support Right Clicks.