### PR TITLE
[hotfix][feat]: add Karazhan Crypts category for SoD realms

### DIFF
--- a/LFGBulletinBoard/dungeons/classic.lua
+++ b/LFGBulletinBoard/dungeons/classic.lua
@@ -100,6 +100,7 @@ local LFGActivityIDs = {
     ["KAZK"] = isSoD and 1609 or nil, -- Tainted Scar (Kazzak)
     ["CRY"] = isSoD and 1611 or nil, -- Crystal Vale (Thunderaan)
     ["NMG"] = isSoD and 1610 or nil, -- Nightmare Grove (Emerald Dragons)
+    ["KARA"] = isSoD and 1693 or nil, -- Karazhan Crypts
 }
 --see https://wago.tools/db2/GroupFinderCategory?build=1.15.2.54332
 local activityCategoryTypeID  = {


### PR DESCRIPTION
Reuses already defined tags for key `KARA` from other game versions of Karazhan.

Uses `ActivityID=1693`
Data for  `C_LFGList.GetActivityInfoTable(1693)` can be found @ https://wago.tools/db2/GroupFinderActivity?build=1.15.6.58866&sort[ID]=desc