### PR TITLE
[hotifx][refactor]: fix issues with AQ being categorized improppely in SoD

### DIFF
--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -80,7 +80,7 @@ local heroicTags = {
 --- Dungeon Tags: for identifying dungeons related to messages.
 local dungeonTags = {
 	AQ20 = { -- Ahn'Qiraj Ruins
-		enGB = "ruins aq20",
+		enGB = "ruins aq20 aqr",
 		deDE = nil,
 		ruRU = "руины ра20 ак20 аку20",
 		frFR = nil,
@@ -90,7 +90,7 @@ local dungeonTags = {
 		ptBR = ""
 	},
 	AQ40 = { -- Ahn'Qiraj Temple
-		enGB = "aq40",
+		enGB = "aq40 aqt",
 		deDE = nil,
 		ruRU = "ан40 ак40 аку40",
 		frFR = nil,
@@ -118,12 +118,6 @@ local dungeonTags = {
 	},
 	KAZK = { -- Lord Kazzak
 		enGB = "kazzak kaz",
-	},
-	CRY = { -- Crystal vale (Thunderaan)(SoD only)
-		enGB = "crystal vale thunderan thunderaan",
-	},
-	NMG = { -- Nightmare Grove (Emerald Dragons)(SoD only)
-		enGB = "grove nmg dragons",
 	},
 	AZN = { -- Azjol-Nerub
 		enGB = "azn an nerub",
@@ -205,14 +199,6 @@ local dungeonTags = {
 		zhTW = nil,
 		zhCN = nil,
 	},
-	DFC = { -- Demon Fall Canyon
-		enGB = "demonfall dfc demon fall canyon",
-		deDE = nil,
-		ruRU = nil,
-		frFR = nil,
-		zhTW = nil,
-		zhCN = nil,
-	},
 	DM = { -- Deadmines
 		enGB = "deadmines vc vancleef dead mines mine",
 		deDE = "todesminen todesmine tm",
@@ -221,7 +207,6 @@ local dungeonTags = {
 		zhTW = "死亡礦坑 死況 死礦",
 		zhCN = "死亡矿坑 死矿",
 	},
-
 	-- When changing tag strings for diremaul dungeons make sure to consider
 	-- other versions of the game since the wings might be referred to differently. 
 	DMW = { -- Dire Maul - Capital Gardens (DMW pre-cata)
@@ -1031,6 +1016,36 @@ local dungeonTags = {
 		zhCN = nil,
 	}
 }
+if isSoD then
+	local sodSpecificTags = { -- appended to associated dungeonTags
+		KARA = { -- Karazhan Crypts
+			enGB = "kc crypts",
+		},
+		AQ20 = { -- Ruins of Ahn'Qiraj
+			enGB = "aq10",
+		},
+		CRY = { -- Crystal vale (Thunderaan)
+			enGB = "crystal vale thunderan thunderaan",
+		},
+		NMG = { -- Nightmare Grove (Emerald Dragons)
+			enGB = "grove nmg dragons",
+		},
+		DFC = { -- Demonfall Canyon
+			enGB = "demonfall dfc demon fall canyon",
+		},
+	}
+	for key, tagsByLoc in pairs(sodSpecificTags) do
+		if not dungeonTags[key] then
+			dungeonTags[key] = tagsByLoc
+		else for locale, tag in pairs(tagsByLoc) do
+			if not dungeonTags[key][locale] then
+				dungeonTags[key][locale] = tag
+			else
+				dungeonTags[key][locale] = strjoin(" ", dungeonTags[key][locale], tag)
+			end
+		end end
+	end
+end
 dungeonTags["DEADMINES"] = { enGB = "dm" } -- should normalize "DM" to "DEADMINES" at somepoint.
 
 --- Misc. categeories tags (these are core to the addon) 

--- a/LFGBulletinBoard/dungeons/classic.lua
+++ b/LFGBulletinBoard/dungeons/classic.lua
@@ -92,8 +92,8 @@ local LFGActivityIDs = {
     ["ST"] = not isSoD and 810 or 1606,  -- Sunken Temple
     ["ONY"] = not isSoD and 838 or 1612,  -- Onyxia
     ["MC"] = not isSoD and 839 or 1613,  -- Molten Core
-    ["AQ20"] = not isSoD and 842 or 1614,  -- Ahn'Qiraj Ruins
-    ["AQ40"] = not isSoD and 843 or 1615,  -- Ahn'Qiraj Temple
+    ["AQ20"] = not isSoD and 842 or 1615,  -- Ahn'Qiraj Ruins
+    ["AQ40"] = not isSoD and 843 or 1614,  -- Ahn'Qiraj Temple
     -- SoD Specific
     ["DFC"] = isSoD and 1607 or nil, -- Demon Fall Canyon
     ["AZGS"] = isSoD and 1608 or nil, -- Storm Cliffs (Azuregoes)


### PR DESCRIPTION
## In this PR: 
**[hotfix]: fix incorrect activityIDs for AQ20 and AQ40 in SoD**
- they were simply swapped, so AQ20 was showing as AQ40 and vice versa

**[refactor]: move SoD specific tags to conditional block**
- better organization of tags and prevents leaks to other clients.
- adds additional "SoD only" tags to `AQ20`