### PR TITLE
[hotfix]: updates for Cataclysm patch `4.4.2`

### DIFF
--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -1,4 +1,4 @@
-## Interface: 11506, 40401
+## Interface: 11506, 40402
 ## Title: LFG Bulletin Board
 ## Notes: Sort LFG/LFM Messages
 ## Version: 3.43

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -233,9 +233,8 @@ local dungeonTags = {
 		zhTW = "厄東 惡東 噩東",
 		zhCN = "厄运东",
 	},
-
-	NULL = { -- Dragon Soul
-
+	DS = { -- Dragon Soul
+		enGB = "ds deathwing",
 	},
 	DTK = { -- Drak'Tharon Keep
 		enGB = "dtk drak draktharon drak'tharon",
@@ -606,7 +605,7 @@ local dungeonTags = {
 		zhCN = "禁魔监狱",
 	},	
 	BOT2 = { -- The Bastion of Twilight
-		enGB = "bot bastion twilight bot10 bot25",
+		enGB = "bot bastion bot10 bot25",
 		deDE = nil,
 		ruRU = "сб",
 		frFR = nil,

--- a/LFGBulletinBoard/changelog.txt
+++ b/LFGBulletinBoard/changelog.txt
@@ -1,12 +1,18 @@
 Group Bulletin Board
 
 3.43
- - English keywords added for improved SoD dungeon matching.
+- General:
+  - added option to change the sound output channel for the "Play sound on new request" setting
+- Season of Discovery:
+  - English keywords added for improved SoD dungeon matching.
     - "kc" and "crypts" added to Karazhan Crypts
     - "aqt" for AQ40
     - "aqr" and "aq10" for AQ20
- - fixed issue with AQ20 (Ruins) and AQ40 (Temple) requests being categorized backwards in SoD
- - added option to change the sound output channel for the "Play sound on new request" setting
+  - fixed issue with AQ20 (Ruins) and AQ40 (Temple) requests being categorized backwards in SoD
+- Cataclysm:
+  - hotfixes for lua errors in the latest cataclysm patch 4.4.2
+  - adds "Dragon Soul" to available raids
+  - Note: for the new Twilight Dungeons users could add the keyword "twilight" to `Random Dungeons` patterns in the "Additional Filters" panel.
 
 3.42
  - Adds "Karazhan Crypts" dungeon category for SoD servers.

--- a/LFGBulletinBoard/dungeons/cata.lua
+++ b/LFGBulletinBoard/dungeons/cata.lua
@@ -80,7 +80,7 @@ local LFGDungeonIDs = {
 	DME = 34,	-- Dire Maul - East (Renamed in Cata)
 	DMN = 38,	-- Dire Maul - North (Renamed in Cata)
 	DMW = 36,	-- Dire Maul - West (Renamed in Cata)
-	-- DS = 447,	-- Dragon Soul
+	DS = 447,	-- Dragon Soul
 	DTK = 214,	-- Drak'Tharon Keep
 	-- END_TIME = 435,	-- End Time
 	NULL = 417,	-- Fall of Deathwing (LFR)
@@ -383,6 +383,10 @@ local infoOverrides = {
 	HOLLOW = { expansionID = Expansions.Cataclysm },
 }
 
+local getBestActivityName = function(activityInfo)
+	return (activityInfo.shortName and activityInfo.shortName ~= "" and activityInfo.shortName)
+		or activityInfo.fullName
+end
 ---@type {[DungeonID]: DungeonInfo}
 local dungeonInfoCache = {}
 local infoByTagKey = {}
@@ -394,7 +398,7 @@ do
 		if activityInfo then -- spoofied entries will be nil
 			local additionalInfo = groupIDAdditionalInfo[activityInfo.groupFinderActivityGroupID]
 			cached = {
-				name = activityInfo.shortName or activityInfo.fullName,
+				name = getBestActivityName(activityInfo),
 				minLevel = activityInfo.minLevel,
 				maxLevel = activityInfo.maxLevel,
 				expansionID = additionalInfo.expansionID,


### PR DESCRIPTION
- adds Dragon Soul to the Cataclysm raids list
- fixes some empty string returns in dungeon data generation stage caused by updates to db2 tables.
-  toc and changelog updates for 3.43 release