### PR TITLE
[minor][ui]: fix member levels being truncated in `LFGTool` tooltip

### DIFF
--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -466,7 +466,7 @@ do
 		frame.Level:SetPoint("LEFT", frame.Name, "RIGHT", 2, 0)
 		frame.Level:SetJustifyH("CENTER")
 		frame.Level:SetJustifyV("MIDDLE")
-		frame.Level:SetWidth(26)
+		frame.Level:SetWidth(28)
 		frame.RoleIcon = frame:CreateTexture(nil, "ARTWORK")
 		frame.RoleIcon:SetSize(13, 13)
 		frame.RoleIcon:SetPoint("LEFT", frame.Level, "RIGHT", 2, 0)


### PR DESCRIPTION
- seems to be happening only on some resolutions

**image of bug**
![image](https://github.com/user-attachments/assets/fb2f72d3-2fc3-4594-b6d4-5acefca45ffc)