### PR TITLE
[feat]: add "Scarlet Enclave" SoD raid support

### DIFF
--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -1032,6 +1032,9 @@ if isSoD then
 		DFC = { -- Demonfall Canyon
 			enGB = "demonfall dfc demon fall canyon",
 		},
+		ENCLAVE = { -- Scarlet Enclave
+			enGB = "enclave scarlet se",
+		}
 	}
 	for key, tagsByLoc in pairs(sodSpecificTags) do
 		if not dungeonTags[key] then

--- a/LFGBulletinBoard/dungeons/classic.lua
+++ b/LFGBulletinBoard/dungeons/classic.lua
@@ -101,6 +101,7 @@ local LFGActivityIDs = {
     ["CRY"] = isSoD and 1611 or nil, -- Crystal Vale (Thunderaan)
     ["NMG"] = isSoD and 1610 or nil, -- Nightmare Grove (Emerald Dragons)
     ["KARA"] = isSoD and 1693 or nil, -- Karazhan Crypts
+    ["ENCLAVE"] = 7777 or nil -- Scarlet Enclave (spoofed until real ActivityID known)
 }
 --see https://wago.tools/db2/GroupFinderCategory?build=1.15.2.54332
 local activityCategoryTypeID  = {
@@ -134,6 +135,12 @@ local infoOverrides = {
         maxLevel = 60, -- DMN max
         typeID = DungeonType.Dungeon
     },
+    -- once the activityID for scarlet enclave is known we can get data from LFGList API instead.
+    ENCLAVE = {
+        name = GetRealZoneText(2856),
+        minLevel = 60, maxLevel = 60,
+        typeID = DungeonType.Raid
+    }
 }
 
 ---@type {[DungeonID]: DungeonInfo}


### PR DESCRIPTION
- uses a spoofed ActivityID with localized names ripped from `GetRealZoneText`
 - allows the 'match by dungeon name' to work in the `LFGTool`, even when we don't know the actual ActivityID that will be used by blizzard for this raid.
- adds basic english patterns of `"scarlet" "enclave" "se"`
  - users may see false grouping of messages containing "scarlet" since it's a common word