### PR TITLE
[hotfix]: variety of small fixes mostly around Scarlet Enclave parsing

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -33,6 +33,12 @@ function GBB.GetDungeonNames()
 	for _, key in ipairs(dungeonKeys) do
 		defaultLocalizations[key] = GBB.GetDungeonInfo(key).name
 	end
+	-- note: `GetSortedDungeonKeys` does not include the `SM2` and `DM2` dungeons keys by design.
+	-- (because they are not actually dungeons, but rather a combination of dungeons)
+	-- so we need to add them manually
+	defaultLocalizations["SM2"] = GBB.GetDungeonInfo("SM2").name
+	defaultLocalizations["DM2"] = GBB.GetDungeonInfo("DM2").name
+
 	for key, translations in pairs(miscCategoryLocalizations) do
 		defaultLocalizations[key] = translations[clientLocale] or translations.enUS
 	end

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -475,7 +475,9 @@ local function SettingsButton_OnMouseDown(self, clickType)
 	-- Close menu curently open click menu if it exists
 	if currentOpenMenu and incomingDescription == settingsButtonMenuContext.lastDescription then
 		settingsButtonMenuContext:CloseMenu(currentOpenMenu)
+		PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_OFF)
     else  -- open menu when: No menu is currently open, or switching click menus
+		PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON)
         settingsButtonMenuContext:OpenMenu(self, incomingDescription)
     end
 end

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -489,10 +489,17 @@ local shouldUpdateTagKey = function(pattern, current, incoming)
 	assert(incoming, "shouldUpdateTagKey: incoming key is nil", pattern, current, incoming)
 	if current == incoming then return false end
 	if not current then return true end
-	incoming = GBB.GetDungeonInfo(incoming)
-	current = GBB.GetDungeonInfo(current); 
-	current = current and current.expansionID or -1
-	incoming = incoming and incoming.expansionID or -1
+	local incInfo = GBB.GetDungeonInfo(incoming) or {};
+	local curInfo = GBB.GetDungeonInfo(current) or {};
+	if incInfo.expansionID ~= curInfo.expansionID then
+		return (incInfo.expansionID or -1) >= (curInfo.expansionID or -1)
+	end
+	if incInfo.typeID ~= curInfo.typeID then
+		return (incInfo.typeID or -1) >= (curInfo.typeID or -1)
+	end
+	if incInfo.maxLevel ~= curInfo.maxLevel then
+		return (incInfo.maxLevel or -1) >= (curInfo.maxLevel or -1)
+	end
 	return incoming >= current
 end
 ---Sets the `GBB.tagList` table with the tags specified by the given locale.

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -676,7 +676,21 @@ function GBB.GetDungeons(msg,name)
 				hasTag=true
 				isGood=true
 			else
-				dungeons[x]=true
+				local skip = false
+				if dungeons.TRADE and x ~= "TRADE" then
+					-- if a trade keyword and dungeon keyword are both present
+					-- disambiguate between items and dungeons.
+
+					-- useful for dungeons with more general search patterns
+					-- like "Throne of Four Winds"
+
+					local itemPattern =  "|hitem.*|h%[.*"..word..".*%]"
+					if msg:lower():find(itemPattern) then
+						-- keyword was part of a linked item not a dungeon request
+						skip = true
+					end
+				end
+				dungeons[x]= not skip
 			end
 		end
 		wordcount = #(parts)

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -1054,7 +1054,7 @@ dungeonTags["DEADMINES"] = { enGB = "dm" } -- should normalize "DM" to "DEADMINE
 -- see `CustomCategories.lua` for additional user-editable categories/tags
 local miscTags = {
 	TRADE = { -- Trade Services
-	  enGB = "buy buying sell selling wts wtb hitem henchant htrade enchanter",
+	  enGB = "buy buying sell selling wts wtb hitem henchant htrade enchanter wtt",
 	  deDE = "kaufe verkauf kauf verkaufe ah vk tg trinkgeld trinkgold vz schneider verzauberer verzaubere schliesskassetten schließkassetten kassetten schlossknacken schloßknacken alchimie",
 	  ruRU = "куплю продам втс втб чантера чант энчантера скрафчу сделаю чарю чары",
 	  frFR = "achete vends enchanteur vend",


### PR DESCRIPTION
## In this PR
**[minor]: Add sound effects to the bulletin board settings button dropdown**

**[fix]: additional criteria to handle tag string collision priorities**

- when initially implemented, tags would get priorizited by expansion only
- now prioritized by expansion > dungeon type (dungeon, raid, battleground) > max level.
- allows the "scarlet" tag to be used to for Scarlet Enclave (over Scarlet Monastery) on SoD builds

**hotfix: better distinguish dungeons from items in `TRADE` requests**

- should reduce the amount of "Scarlet" item in trade getting categorized as part of Scarlet Enclave
- before
  - ![Discord_s6s6uTJ6T0](https://github.com/user-attachments/assets/9e934773-69c4-40e9-822c-e72391255959)
- after
  - ![image](https://github.com/user-attachments/assets/80a19fd1-5a62-4181-be53-daf01fde728c)
