### PR TITLE
[refactor]: use `Blizzard_Menu` for request Entry and Header popup menus

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.xml
+++ b/LFGBulletinBoard/GroupBulletinBoard.xml
@@ -255,10 +255,6 @@
 			<OnEvent>
 				GroupBulletinBoard_Addon.OnEvent(event, ...);
 			</OnEvent>
-			
-			<OnMouseDown>
-				GroupBulletinBoard_Addon.ClickFrame(self,button)
-			</OnMouseDown>
 		</Scripts>
 	</Frame>
 	


### PR DESCRIPTION
- Also trimmed down the amount of options.
  - planning on re-adding them to the settings button _right-click_ version dropdown menu.

**Related Issues**:
 - #73 

**Images**:
BEFORE
![Discord_syqJ34Nwvf](https://github.com/user-attachments/assets/53b54d41-e150-45f9-a22e-f370d4196ca2)
AFTER
![Discord_TWqYZecBbD](https://github.com/user-attachments/assets/928708fa-9df5-4920-91a3-d658b1e935fb) ![image](https://github.com/user-attachments/assets/e4a1c301-6764-445f-bba1-c874ad92ef38)
