### PR TITLE
[refactor]: tidy `RequestList.lua` header and entry frame implementations

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -733,7 +733,8 @@ function GBB.Init()
     local GroupBulletinBoardFrame = GroupBulletinBoardFrame
 	GroupBulletinBoardFrame:SetResizeBounds(400,170)
 	GroupBulletinBoardFrame:SetClampedToScreen(true)
-	GBB.UserLevel=UnitLevel("player")
+	GBB.UserLevel = UnitLevel("player")
+	GBB.Tool.RegisterEvent("PLAYER_LEVEL_UP", function() GBB.UserLevel = UnitLevel("player") end)
 	GBB.UserName=(UnitFullName("player"))
 	GBB.ServerName=GetRealmName()
 	GBB.RealLevel = {} -- recently seen player levels

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -805,7 +805,6 @@ function GBB.Init()
 
 	-- Reset Request-List
 	GBB.RequestList={}
-	GBB.FramesEntries={}
 
 	-- Timer-Stuff
 	GBB.MAXTIME=time() +60*60*24*365 --add a year!

--- a/LFGBulletinBoard/GroupBulletinBoard.xml
+++ b/LFGBulletinBoard/GroupBulletinBoard.xml
@@ -257,20 +257,7 @@
 			</OnEvent>
 		</Scripts>
 	</Frame>
-	
-	<Frame hidden="false" name="GroupBulletinBoard_TmpHeader" virtual="true">
-		<Layers>
-			<Layer level="ARTWORK">
-				<FontString name="$parent_name" text="samplename" inherits="GameFontNormal" maxLines="1" justifyH="LEFT" justifyV="TOP"/>					
-			</Layer>
-		</Layers>
-		<Scripts>
-			<OnMouseDown>
-				GroupBulletinBoard_Addon.ClickDungeon(self,button)
-			</OnMouseDown>
-		</Scripts>
-	</Frame>
-		<Frame hidden="false" name="GroupBulletinBoard_LfgTmpHeader" virtual="true">
+	<Frame hidden="false" name="GroupBulletinBoard_LfgTmpHeader" virtual="true">
 		<Layers>
 			<Layer level="ARTWORK">
 				<FontString name="$parent_name" text="samplename" inherits="GameFontNormal" maxLines="1" justifyH="LEFT" justifyV="TOP"/>					

--- a/LFGBulletinBoard/GroupBulletinBoard.xml
+++ b/LFGBulletinBoard/GroupBulletinBoard.xml
@@ -270,41 +270,6 @@
 			</OnMouseDown>
 		</Scripts>
 	</Frame>
-	<Frame hidden="false" name="GroupBulletinBoard_TmpRequest" virtual="true">
-	
-		<Layers>
-			<Layer level="ARTWORK">				
-				<FontString name="$parent_name" text="samplename" inherits="GameFontNormal" maxLines="1" justifyH="LEFT" justifyV="TOP">
-					<Size>
-						<AbsDimension x="100" y=""/>
-					</Size>
-					<color b="1" g="1" r="1" a="1"/>
-				</FontString>
-				<FontString name="$parent_message" text="samplemsg" inherits="GameFontNormal" maxLines="1" justifyH="LEFT" justifyV="TOP">
-					<color b="1" g="1" r="1" a="1"/>
-				</FontString>
-				<FontString name="$parent_time" text="samplename" inherits="GameFontNormal" maxLines="1" justifyH="RIGHT" justifyV="TOP">
-					<Size>
-						<AbsDimension x="75" y=""/>
-					</Size>
-					<color b="1" g="1" r="1" a="1"/>
-				</FontString>
-			</Layer>
-		</Layers>
-		<Scripts>
-			<OnMouseDown>
-				GroupBulletinBoard_Addon.ClickRequest(self,button)
-			</OnMouseDown>
-			<OnEnter>
-				GroupBulletinBoard_Addon.RequestShowTooltip(self)
-			</OnEnter>
-			<OnLeave>
-				GroupBulletinBoard_Addon.RequestHideTooltip(self)
-			</OnLeave>					
-		</Scripts>
-		
-	</Frame>	
-
 		<Frame hidden="false" name="GroupBulletinBoard_LfgTmpHeader" virtual="true">
 		<Layers>
 			<Layer level="ARTWORK">


### PR DESCRIPTION
### In this PR:
**[refactor]: clean up request entry frame implementation**

- moved to using a mixin style implementation
- clarified logic around sub-frame placements for the different layout modes
- using a reusable frame pool for the manage recycling frames
- goal is to make entry frame setup compatible with a WoWScrollBox in the future
  - and flexible enough to be reused for LFGToolList in the future


**[refactor]: clean up request list header frame implementation**

- see commit message for request list entry frame refactors
