### PR TITLE
[refactor]: modularize & reorganize methods and references for `RequestList.lua`

### DIFF
--- a/LFGBulletinBoard/CustomCategories.lua
+++ b/LFGBulletinBoard/CustomCategories.lua
@@ -310,7 +310,7 @@ local removeFilterFromRequestList = function(key) ---@param key string
     end
     if anyRemoved then
         Addon.RequestList = requestList
-        Addon.UpdateList()
+        Addon.ChatRequests.UpdateRequestList()
     end
 end
 

--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -201,11 +201,12 @@ function GBB.GetDungeonSort(additonalCategories)
 	dungeonSort[dungeonSort["SM2"]] = "SM2"
 	dungeonSort[dungeonSort["DM2"]] = "DM2"
 
-	-- This is set to a high index with no reverse link because-
-	-- we dont ever want to show this in the list during `UpdateList()` (might not be relevant anymore)
-	-- Ideally the "DEADMINES" key should never make it to the `req.dungeon` field as it should be converted to either "DM" or "DM2"/"DMW"/"DME"/"DMN" in GBB.GetDungeon() 
+	-- This is set to a high index with no reverse link because we dont ever want to show this in `ChatRequests.UpdateRequestList()` (might not be relevant anymore)
+	-- Ideally the "DEADMINES" key should never make it to the `req.dungeon` field as it should be converted to either-
+	-- "DM" or "DM2"/"DMW"/"DME"/"DMN" in `getRequestMessageCategories()`
+	-- keeping this shim here until i fully understand what it even doing, though i suspect it's a relic of old code.
 	dungeonSort["DEADMINES"] = GBB.ENDINGDUNGEONEND + 20
-	
+
 	return dungeonSort
 end
 

--- a/LFGBulletinBoard/LfgToolList.lua
+++ b/LFGBulletinBoard/LfgToolList.lua
@@ -661,7 +661,7 @@ local function InitializeEntryItem(entry, node)
 		entry.Name:SetJustifyV("TOP")
 		entry.Message:SetJustifyH("LEFT")
 		entry.Message:SetNonSpaceWrap(false)
-		if GBB.DontTrunicate then GBB.ClearNeeded=true end
+
 		-- add highlight hover tex. Draw on "HIGHTLIGHT" layer to use base xml highlighting script
 		local hoverTex = entry:CreateTexture(nil, "HIGHLIGHT")
 		-- padding used compensate text clipping out of its containing frame

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -277,7 +277,7 @@ function GBB.OptionsUpdate()
 	fixSecondaryTagFilters()
 	GBB.CreateTagList()
 	GBB.MinimapButton.UpdatePosition()
-	GBB.ClearNeeded = true
+	GBB.ChatRequests.UpdateRequestList(true)
 end
 
 --- Setup the options panels, creating and initializing settings widgets and their saved variables.

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -1069,7 +1069,7 @@ local miscTags = {
 	  zhTW = nil,
 	  zhCN = nil,
 	},
-	MISC = { --[[Misc messages, no defined tags. see `GBB.GetDungeons`]]},
+	MISC = { --[[Misc messages, no defined tags. see getRequestDungeons in RequestList.lua]]},
 }
 
 --- Secondary Dungeon Tags: used for groupable categories such as Scarlet Monastery


### PR DESCRIPTION
method renames:
 - `GBB.GetDungeons` -> `getRequestMessageCategories`
 - `GBB.ParseMessage` -> `parseMessageForRequestList`
 - `GBB.FoldAllDungeon` -> `foldAllHeaders`
 - `GBB.UnfoldAllDungeon` -> `unfoldAllHeaders`
 - `GBB.UpdateList` -> `GBB.ChatRequests.UpdateRequestList`
 - `GBB.Clear` -> folded into `GBB.ChatRequests.UpdateRequestList`

- Moved handlers for `CHAT_MSG_` events, related to the request list, into `RequestList.lua`  for better colocation.
- Folded `GBB.Clear` into the new `UpdateRequestList` since it wasn't referenced outside of the file
- Move public accessible logic specific to the request list into a `ChatRequest` module within `GBB`
  - cleans up the GBB namespace a bit.