### PR TITLE
[fix]: locking the bulletin board now prevents resizing

### DIFF
--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -912,7 +912,7 @@ function GBB.Init()
 		tinsert(UISpecialFrames, GroupBulletinBoardFrame:GetName()) --enable ESC-Key to close
 	end
 	
-	GBB.Tool.EnableSize(GroupBulletinBoardFrame,8,nil,function()	
+	local setBorderResizingEnabled = GBB.Tool.EnableSize(GroupBulletinBoardFrame,8,nil,function()
 		GBB.ResizeFrameList()
 		GBB.SaveAnchors()
 		GBB.ChatRequests.UpdateRequestList()
@@ -934,15 +934,22 @@ function GBB.Init()
 			--- `1` if the board is fully opaque; `0` if the board is fully transparent; default=`1`
 			opacity = OptionsUtil.GetSavedVarHandle(GBB.DB.WindowSettings, "opacity", 1),
         }
-        windowSettings.isMovable:AddUpdateHook(setBulletinBoardMovableState)
-        setBulletinBoardMovableState(windowSettings.isMovable:GetValue())
-        local setBulletinBoardInteractiveState = function(isInteractive)
+		-- Handle updates to isMovable
+		local setMovableStates = function(isMovable)
+			setBulletinBoardMovableState(isMovable)
+			setBorderResizingEnabled(isMovable)
+		end
+        windowSettings.isMovable:AddUpdateHook(setMovableStates)
+        setMovableStates(windowSettings.isMovable:GetValue())
+		-- Handle updates to isInteractive
+        local setInteractiveStates = function(isInteractive)
             GBB.ChatRequests.UpdateInteractiveState()
             GBB.LfgTool:UpdateInteractiveState()
             GroupBulletinBoardFrame:EnableMouse(isInteractive and windowSettings.isMovable:GetValue())
         end
-        windowSettings.isInteractive:AddUpdateHook(setBulletinBoardInteractiveState)
-        setBulletinBoardInteractiveState(windowSettings.isInteractive:GetValue())
+        windowSettings.isInteractive:AddUpdateHook(setInteractiveStates)
+        setInteractiveStates(windowSettings.isInteractive:GetValue())
+		-- Handle updates to opacity
 		local setBulletinBoardOpacity = function(opacity)
 			GroupBulletinBoardFrame:SetAlpha(opacity)
 		end

--- a/LFGBulletinBoard/LibGPIToolBox.lua
+++ b/LFGBulletinBoard/LibGPIToolBox.lua
@@ -463,19 +463,26 @@ function Tool.EnableSize(frame,border,OnStart,OnStop)
 	
 	frame:EnableMouse(true)
 	frame:SetResizable(true)	
-	
-	-- path= "Interface\\AddOns\\".. TOCNAME .. "\\Resize\\"
-	
-	CreateSizeBorder(frame,"BOTTOM","BOTTOMLEFT", border, border, "BOTTOMRIGHT", -border, 0,"Interface\\CURSOR\\UI-Cursor-SizeLeft",45,OnStart,OnStop)
-	CreateSizeBorder(frame,"TOP","TOPLEFT", border, 0, "TOPRIGHT", -border, -border,"Interface\\CURSOR\\UI-Cursor-SizeLeft",45,OnStart,OnStop)
-	CreateSizeBorder(frame,"LEFT","TOPLEFT", 0,-border, "BOTTOMLEFT", border, border,"Interface\\CURSOR\\UI-Cursor-SizeRight",45,OnStart,OnStop)
-	CreateSizeBorder(frame,"RIGHT","TOPRIGHT",-border,-border, "BOTTOMRIGHT", 0, border,"Interface\\CURSOR\\UI-Cursor-SizeRight",45,OnStart,OnStop)
-	
-	CreateSizeBorder(frame,"TOPLEFT","TOPLEFT", 0,0, "TOPLEFT", border, -border,"Interface\\CURSOR\\UI-Cursor-SizeRight",0,OnStart,OnStop)
-	CreateSizeBorder(frame,"BOTTOMLEFT","BOTTOMLEFT", 0,0, "BOTTOMLEFT", border, border, "Interface\\CURSOR\\UI-Cursor-SizeLeft",0,OnStart,OnStop)
-	CreateSizeBorder(frame,"TOPRIGHT","TOPRIGHT", 0,0, "TOPRIGHT", -border, -border, "Interface\\CURSOR\\UI-Cursor-SizeLeft",0,OnStart,OnStop)
-	CreateSizeBorder(frame,"BOTTOMRIGHT","BOTTOMRIGHT", 0,0, "BOTTOMRIGHT", -border, border, "Interface\\CURSOR\\UI-Cursor-SizeRight",0,OnStart,OnStop)
-	
+
+	local borders = {
+		CreateSizeBorder(frame,"BOTTOM","BOTTOMLEFT", border, border, "BOTTOMRIGHT", -border, 0,"Interface\\CURSOR\\UI-Cursor-SizeLeft",45,OnStart,OnStop),
+		CreateSizeBorder(frame,"TOP","TOPLEFT", border, 0, "TOPRIGHT", -border, -border,"Interface\\CURSOR\\UI-Cursor-SizeLeft",45,OnStart,OnStop),
+		CreateSizeBorder(frame,"LEFT","TOPLEFT", 0,-border, "BOTTOMLEFT", border, border,"Interface\\CURSOR\\UI-Cursor-SizeRight",45,OnStart,OnStop),
+		CreateSizeBorder(frame,"RIGHT","TOPRIGHT",-border,-border, "BOTTOMRIGHT", 0, border,"Interface\\CURSOR\\UI-Cursor-SizeRight",45,OnStart,OnStop),
+		CreateSizeBorder(frame,"TOPLEFT","TOPLEFT", 0,0, "TOPLEFT", border, -border,"Interface\\CURSOR\\UI-Cursor-SizeRight",0,OnStart,OnStop),
+		CreateSizeBorder(frame,"BOTTOMLEFT","BOTTOMLEFT", 0,0, "BOTTOMLEFT", border, border, "Interface\\CURSOR\\UI-Cursor-SizeLeft",0,OnStart,OnStop),
+		CreateSizeBorder(frame,"TOPRIGHT","TOPRIGHT", 0,0, "TOPRIGHT", -border, -border, "Interface\\CURSOR\\UI-Cursor-SizeLeft",0,OnStart,OnStop),
+		CreateSizeBorder(frame,"BOTTOMRIGHT","BOTTOMRIGHT", 0,0, "BOTTOMRIGHT", -border, border, "Interface\\CURSOR\\UI-Cursor-SizeRight",0,OnStart,OnStop),
+	}
+	local setResizingEnabled = function(enabled)
+		for _, border in ipairs(borders) do
+			border:SetScript("OnEnter", enabled and SizingEnter or nil)
+			border:SetScript("OnLeave", enabled and SizingLeave or nil)
+			border:SetScript("OnMouseDown", enabled and SizingStart or nil)
+			border:SetScript("OnMouseUp", enabled and SizingStop or nil)
+		end
+	end
+	return setResizingEnabled
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
- fixes #381 
- making the board non interactive still keeps resizing behavior since the board position is intentionally still movable in that state.