### PR TITLE
[hotfix][feat]: Add option to bypass link disqualification for custom filter keywords

### DIFF
--- a/LFGBulletinBoard/Localization.lua
+++ b/LFGBulletinBoard/Localization.lua
@@ -97,6 +97,16 @@ local localizedAddonDisplayStrings = {
 		zhCN = "删除请求",
 		zhTW = "刪除要求",
 	},
+	IGNORE_ITEM_LINKS = {
+		enUS = "Ignore Item Links",
+		deDE = "Gegenstandslinks ignorieren",
+		esMX = "Ignorar enlaces de objetos",
+		frFR = "Ignorer les liens d’objets",
+		ptBR = "Ignorar links de itens",
+		ruRU = "Игнорировать ссылки на предметы",
+		zhCN = "忽略物品链接",
+		zhTW = "忽略物品連結",
+	},
 	JOIN_REQUEST_HEADER = {
         enUS = "Alt+Click to Request to Join Group",
         deDE = "Alt+Klick, um Beitritt zur Gruppe anzufragen",

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -263,11 +263,17 @@ local function getRequestMessageCategories(msg, sender, fromLFGChannel)
 				hasSearchTag = true
 			else
 				local skip = false
-				if dungeons.TRADE and categoryTagKey ~= "TRADE" then
-					-- if a trade keyword and dungeon keyword are both present, disambiguate between items and dungeons.
-					-- useful for dungeons with more general search patterns like "Throne of Four Winds"
-					local itemPattern =  "|hitem.*|h%[.*"..word..".*%]"
-					if msg:lower():find(itemPattern) then skip = true end
+				if dungeons.TRADE and categoryTagKey ~= "TRADE"
+				then
+					local customCategory = GBB.DB.CustomFilters[categoryTagKey] ---@type CustomFilter?
+					-- only check custom categories if they are set to NOT includes item links
+					-- all other categories are still checked for item links
+					if not customCategory or not customCategory.includeItemLinks then
+						-- if a trade keyword and dungeon keyword are both present, disambiguate between items and dungeons.
+						-- useful for dungeons with more general search patterns like "Throne of Four Winds"
+						local itemPattern =  "|hitem.*|h%[.*"..word..".*%]"
+						if msg:lower():find(itemPattern) then skip = true end
+					end
 				end
 				dungeons[categoryTagKey] = not skip
 			end


### PR DESCRIPTION
- option toggle accessed via a new settings button next to each custom filter's header
- fixes #382 
- ![image](https://github.com/user-attachments/assets/ff93c4aa-5a0b-4168-ab58-4bb320c6cb6b)
