### PR TITLE
[hotfix]: assert client dungeon keys are loaded before needed in `Tags.lua`

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -9,11 +9,6 @@ local isSoD = isClassicEra and C_Seasons.GetActiveSeason() == Enum.SeasonID.Seas
 local debug = false
 local print = function(...) if debug then print('['..TOCNAME.."] ",...) end end
 
--- todo: this is a hack to only use this system for Cata+ clients
-if WOW_PROJECT_ID >= WOW_PROJECT_CATACLYSM_CLASSIC then
-	GBB.Dungeons.ProcessActivityInfo()
-end
-
 function GBB.GetDungeonNames()
 	local miscCategoryLocalizations = {
 		-- note: enUS treated as a fallback when no locale specific key exists

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -1157,8 +1157,16 @@ GBB.heroicTagsLoc = langSplit(heroicTags)
 GBB.Misc = (function() local t = {}; for k, _ in pairs(miscTags) do table.insert(t,k); end return t; end)()
 
 GBB.dungeonTagsLoc = dungeonTagsLoc
+
+-- todo: this is a hack to only use this system for Cata+ clients
+if WOW_PROJECT_ID >= WOW_PROJECT_CATACLYSM_CLASSIC then
+	GBB.Dungeons.ProcessActivityInfo()
+end
+
 -- Remove any unused dungeon tags based on game version
 local clientDungeonKeys = GBB.GetSortedDungeonKeys() -- includes raids/bgs/dungeons for all valid expansions.
+assert(next(clientDungeonKeys), "No client dungeons found. Was `ProcessActivityInfo()` called?")
+
 clientDungeonKeys = (function() ---@type table<string, boolean> convert to map
 	local t = {}; for _, key in ipairs(clientDungeonKeys) do t[key] = true; end return t;
 end)()


### PR DESCRIPTION
- was causing issue where all tags were being removed by the pruning logic in Tags.lua