### PR TITLE
[feat]: add "Isolate Requests" option and add MoP World Bosses

### DIFF
--- a/LFGBulletinBoard/CustomCategories.lua
+++ b/LFGBulletinBoard/CustomCategories.lua
@@ -39,6 +39,7 @@ local ExpansionEnum  = (Addon.Enum --[[@as AddonEnum]]).Expansions
 ---@field isHidden boolean? # `true` if the filter should be hidden from UI. (used instead of deletion for saved presets)
 ---@field isDisabled boolean # `true` if the preset should be completely disabled for the current client (used by presets only)
 ---@field includeItemLinks boolean? # `true` if the filter should parse item links for keys words
+---@field isolateCategory boolean? # `true` if the filter should be isolated from other categories in the bulletin board
 
 ---@type {[string]: CustomFilter}
 local presets = {
@@ -490,9 +491,14 @@ local createSettingsDropdownButton = function(parent)
     button:SetupMenu(function(_, rootDescription)
         local categoryData = GroupBulletinBoardDB.CustomFilters[button.filterKey]
         if not categoryData then return end
-        local isSelected = function() return not categoryData.includeItemLinks end
-        local setSelected = function() categoryData.includeItemLinks = isSelected() end
-        rootDescription:CreateCheckbox(Addon.L.IGNORE_ITEM_LINKS, isSelected, setSelected)
+        rootDescription:CreateCheckbox(Addon.L.IGNORE_ITEM_LINKS,
+            function() return not categoryData.includeItemLinks end, -- note; this option is inverted.
+            function() categoryData.includeItemLinks = not categoryData.includeItemLinks end
+        )
+        rootDescription:CreateCheckbox(Addon.L.ISOLATE_CATEGORY,
+            function() return categoryData.isolateCategory end,
+            function() categoryData.isolateCategory = not categoryData.isolateCategory end
+        )
     end)
     return button;
 end

--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -75,7 +75,7 @@ local classicDungeonLevels = GBB.GetDungeonLevelRanges(GBB.Enum.Expansions.Class
 
 local mistsDungeonKeys = GBB.GetSortedDungeonKeys(
 	GBB.Enum.Expansions.Mists,
-	{ GBB.Enum.DungeonType.Dungeon, GBB.Enum.DungeonType.Raid }
+	{ GBB.Enum.DungeonType.Dungeon, GBB.Enum.DungeonType.Raid, GBB.Enum.DungeonType.WorldBoss }
 );
 local cataDungeonKeys = GBB.GetSortedDungeonKeys(
 	GBB.Enum.Expansions.Cataclysm,

--- a/LFGBulletinBoard/GroupBulletinBoard.lua
+++ b/LFGBulletinBoard/GroupBulletinBoard.lua
@@ -531,7 +531,7 @@ function GBB.CreateTagList ()
 		-- insert a "custom" locale to `dungeonTagsLoc` for custom tags (before calling `setTagListByLocale`).
 		GBB.dungeonTagsLoc["custom"]={}
 		for _, key in ipairs(sortedDungeonKeys) do
-			GBB.dungeonTagsLoc['custom'][key] = GBB.Split(GBB.DB.Custom[key])
+			GBB.dungeonTagsLoc['custom'][key] = GBB.Split(GBB.DB.Custom[key] or "")
 		end
 		setTagListByLocale("custom")
 	end

--- a/LFGBulletinBoard/Localization.lua
+++ b/LFGBulletinBoard/Localization.lua
@@ -115,6 +115,16 @@ local localizedAddonDisplayStrings = {
 		zhCN = "忽略物品链接",
 		zhTW = "忽略物品連結",
 	},
+	ISOLATE_CATEGORY = {
+		enUS ="Isolate Requests",
+		deDE = "Anfragen isolieren",
+		esMX = "Aislar solicitudes",
+		frFR = "Isoler les demandes",
+		ptBR = "Isolar solicitações",
+		ruRU = "Изолировать запросы",
+		zhCN = "隔离请求",
+		zhTW = "隔離請求",
+	},
 	JOIN_REQUEST_HEADER = {
         enUS = "Alt+Click to Request to Join Group",
         deDE = "Alt+Klick, um Beitritt zur Gruppe anzufragen",

--- a/LFGBulletinBoard/Localization.lua
+++ b/LFGBulletinBoard/Localization.lua
@@ -73,6 +73,14 @@ local preLocalizedFallbacks = {
 	-- Language checkboxes 
 	["CboxTagsPortuguese"] = LFG_LIST_LANGUAGE_PTBR,
 	["CboxTagsSpanish"] = LFG_LIST_LANGUAGE_ESES,
+	-- Mists of Pandaria world bosses
+	-- note: these globals only exist in mop classic client, but its the only place they should be used.
+	SHA_OF_ANGER = WORLD_BOSS_SHA_OF_ANGER or "Sha of Anger",
+	GALLEON = WORLD_BOSS_GALLEON or "Galleon",
+	NALAK = WORLD_BOSS_NALAK or "Nalak",
+	OONDASTA = WORLD_BOSS_OONDASTA or "Oondasta",
+	FOUR_CELESTIALS = WORLD_BOSS_FOUR_CELESTIALS or "The Four Celestials",
+	ORDOS = WORLD_BOSS_ORDOS or "Ordos",
 }
 
 -- localized strings keyed by string identifier key

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -378,6 +378,15 @@ local function getRequestMessageCategories(msg, sender, fromLFGChannel)
 		for categoryKey, include in pairs(dungeons) do
 			if include == true then table.insert(validCategories, categoryKey) end
 		end
+		-- check for custom categories which are set to be isolated/exclusive
+		for _, key in ipairs(validCategories) do
+			local customCategory = GBB.DB.CustomFilters[key] ---@type CustomFilter
+			if customCategory and customCategory.isolateCategory then
+				-- if the custom category is isolated, remove all other categories
+				validCategories = { key }
+				break;
+			end
+		end
 	end
 
 	return validCategories, hasHeroicTag, hasBlacklistTag

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -943,7 +943,7 @@ local dungeonTags = {
 
 	-- Mists of Pandaria specific dungeons/raids
 	MSV = { -- "Mogu'shan Vaults"
-		enGB = "msv vaults",
+		enGB = "mgsv msv vaults elegon",
     },
     NIUZAO_TEMPLE = { -- "Siege of Niuzao Temple"
 		enGB = "niu niuzao temple nt",
@@ -955,16 +955,16 @@ local dungeonTags = {
 		enGB = "scarlet halls sh",
     },
     TOT = { -- "Throne of Thunder"
-		enGB = "tot tot10 tot25",
+		enGB = "tot tot10 tot25 thunder",
     },
     MSP = { -- "Mogu'shan Palace"
-		enGB = "palace msp",
+		enGB = "mogu palace msp",
     },
     TOTJS = { -- "Temple of the Jade Serpent"
 		enGB = "jade serpent totjs",
     },
     SPM = { -- "Shado-Pan Monastery"
-		enGB = "monastery spm",
+		enGB = "shadopan monastery spm",
     },
     BREWERY = { -- "Stormstout Brewery"
 		enGB = "brewery stormstout sb brew",

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -976,6 +976,26 @@ local dungeonTags = {
 		enGB = "heart hof",
     },
 
+	-- Mists of Pandaria World Bosses
+	SHA_OF_ANGER = { -- Sha of Anger
+		enGB = "sha shanger",
+	},
+	GALLEON = { -- Galleon
+		enGB = "galleon gal",
+	},
+	NALAK = { -- Nalak
+		enGB = "nalak nal",
+	},
+	OONDASTA = { -- Oondasta
+		enGB = "oondasta ond oond",
+	},
+	ORDOS = { -- Ordos
+		enGB = "ordos ord",
+	},
+	-- FOUR_CELESTIALS = { -- Four Celestials (Unused)
+	-- 	enGB = "chiji xuen yulon niuzao celestials",
+	-- },
+
 	-- PvP
 	RBG = { -- 10v10 Rated Battleground
 		enGB = "rbgs rbg rated",

--- a/LFGBulletinBoard/dungeons/api.lua
+++ b/LFGBulletinBoard/dungeons/api.lua
@@ -2,6 +2,8 @@ local tocName,
 ---@class Addon_DungeonData: Addon_Localization
 addon = ...;
 local isClassicEra = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+
+---@enum ExpansionID
 local Expansion = {
 	Classic = 0,
 	BurningCrusade = 1,
@@ -26,13 +28,14 @@ local DungeonType = isClassicEra and {
     Raid = 2,
     None = 4,
     Battleground = 5, -- in classic, 5 is used for BGs
-    WorldBoss = 6,
+    WorldBoss = 6, -- spoofed
 } or {
 	Dungeon = 1,
 	Raid = 2,
 	Zone = 4,
-	Random = 6,
-	Battleground = 7
+	-- Random = 6, -- unused, kept for consistency with blizzard API, see comment above
+	Battleground = 7,
+	WorldBoss = 8, -- spoofed
 }
 ---@class AddonEnum
 addon.Enum = addon.Enum or {}

--- a/LFGBulletinBoard/dungeons/mists.lua
+++ b/LFGBulletinBoard/dungeons/mists.lua
@@ -3,6 +3,11 @@ local _, addon = ...;
 local DungeonType = addon.Enum.DungeonType
 local Expansions = addon.Enum.Expansions
 
+-- hacky way to get the localization table. rework in the future
+-- side-effects:
+-- custom users set translatiosn in the `Localization` settings panel will not apply to strings used in this file.
+local L = addon.LocalizationInit()
+
 local ActivityIDs = {
     MSV = { -- "Mogu'shan Vaults"
         335, -- "Mogu'shan Vaults (10 Normal)"
@@ -77,10 +82,17 @@ local ActivityIDs = {
         1717, -- "Scholomance (Celestial)"
     },
 }
--- The latest bgs aren't in the ActivityID table, so we need to add/spoof them manually
 local SpoofedActivityIDs = {
+    -- The latest bgs aren't in the ActivityID table, so we need to add/spoof them manually
     SSM = 50001, -- Silvershard Mines
     KOTMOGU = 50002, -- Temple of Kotmogu
+    -- Same for the world bosses
+    SHA_OF_ANGER = 50003, -- Sha of Anger
+    GALLEON = 50004, -- Galleon
+    NALAK = 50005, -- Nalak
+    OONDASTA = 50006, -- Oondasta
+    ORDOS = 50007, -- Ordos
+    -- FOUR_CELESTIALS = 50008, -- Four Celestials
 }
 
 local mistsMaxLevel = GetMaxLevelForExpansionLevel(Expansions.Mists)
@@ -93,6 +105,16 @@ local spoofBattleground = function(name)
         -- consider bg's part of the current expansion
 		expansionID = Expansions.Current,
 	}
+end
+
+local spoofWorldBoss = function(name)
+    return {
+        name = name,
+        typeID = DungeonType.WorldBoss,
+        expansionID = Expansions.Mists,
+        minLevel = 0,
+        maxLevel = 100,
+    }
 end
 
 --- Any info that needs to be overridden/spoofed/adjusted for a specific instances should be done here.
@@ -111,6 +133,12 @@ local infoOverrides = {
     ARENA = {maxLevel = mistsMaxLevel, minLevel = mistsMaxLevel},
     SSM = spoofBattleground(GetRealZoneText(727)),
     KOTMOGU = spoofBattleground(GetRealZoneText(998)),
+    SHA_OF_ANGER = spoofWorldBoss(L.SHA_OF_ANGER),
+    GALLEON = spoofWorldBoss(L.GALLEON),
+    NALAK = spoofWorldBoss(L.NALAK),
+    OONDASTA = spoofWorldBoss(L.OONDASTA),
+    ORDOS = spoofWorldBoss(L.ORDOS),
+    -- FOUR_CELESTIALS = spoofWorldBoss(L.FOUR_CELESTIALS),
 }
 
 for activityKey, activityIDs in pairs(ActivityIDs) do


### PR DESCRIPTION
## In this PR
**[minor][mop]: minor addition to search patterns for Mists dungeons**

**[feat][mop]: add world boss filters**

- adds dedicated filters for Sha of Anger, Galleon, Nalak, Oondasta, and Ordos.
- doesnt add filter for Four Celestials from timeless isle as people dont premake groups for it.


**[feat]: add "Isolate Requests" option to custom/additional filters**

- enabling this option will make it so that messages with the declared keywords for that filter, will only be categorized under that filter in the bulletin board.
